### PR TITLE
style: add `.rustfmt.toml` and format code

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,10 +1,10 @@
+use lsp_types::{DocumentSymbol, DocumentSymbolResponse, MessageType, SymbolKind};
+use tower_lsp::{lsp_types, Client};
+
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 /// Get the tree of ast
 use crate::utils::treehelper::ToPosition;
 use crate::CMakeNodeKinds;
-use lsp_types::{DocumentSymbol, DocumentSymbolResponse, MessageType, SymbolKind};
-use tower_lsp::lsp_types;
-use tower_lsp::Client;
 
 const COMMAND_KEYWORDS: [&str; 5] = [
     "set",

--- a/src/clapargs.rs
+++ b/src/clapargs.rs
@@ -91,8 +91,9 @@ pub enum NeocmakeCli {
 
 #[test]
 fn test_claps() {
-    use super::NeocmakeCli;
     use clap::{CommandFactory, FromArgMatches};
+
+    use super::NeocmakeCli;
     let mut args =
         NeocmakeCli::command().get_matches_from(vec!["neocmakelsp", "format", "-o", "a", "b"]);
 

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1,19 +1,11 @@
 mod builtin;
 mod findpackage;
 mod includescanner;
-use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-use crate::fileapi;
-use crate::languageserver::BUFFERS_CACHE;
-use crate::scansubs::TREE_MAP;
-use crate::utils::treehelper::{get_pos_type, PositionType, ToPoint};
-use crate::utils::{
-    gen_module_pattern, include_is_module, remove_quotation_and_replace_placeholders,
-    DocumentNormalize, LineCommentTmp, CACHE_CMAKE_PACKAGES_WITHKEYS,
-};
-use builtin::{BUILTIN_COMMAND, BUILTIN_MODULE, BUILTIN_VARIABLE};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
+
+use builtin::{BUILTIN_COMMAND, BUILTIN_MODULE, BUILTIN_VARIABLE};
 use tokio::fs;
 use tokio::sync::Mutex;
 use tower_lsp::lsp_types::{
@@ -21,9 +13,15 @@ use tower_lsp::lsp_types::{
     Position,
 };
 
-use crate::CMakeNodeKinds;
-
-use std::sync::LazyLock;
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::languageserver::BUFFERS_CACHE;
+use crate::scansubs::TREE_MAP;
+use crate::utils::treehelper::{get_pos_type, PositionType, ToPoint};
+use crate::utils::{
+    gen_module_pattern, include_is_module, remove_quotation_and_replace_placeholders,
+    DocumentNormalize, LineCommentTmp, CACHE_CMAKE_PACKAGES_WITHKEYS,
+};
+use crate::{fileapi, CMakeNodeKinds};
 
 pub type CompleteKV = HashMap<PathBuf, Vec<CompletionItem>>;
 
@@ -892,6 +890,7 @@ fn comment_mark_test() {
 fn test_complete() {
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
 
     let file_info = r#"
@@ -976,6 +975,7 @@ endfunction()
 fn test_complete_win() {
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
 
     let file_info = "set(AB \"100\")\r\n# test hello \r\nfunction(bb)\r\nendfunction()".normalize();

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -1,8 +1,10 @@
-/// builtin Commands and vars
-use anyhow::Result;
+use std::collections::HashMap;
+use std::iter::zip;
 use std::process::Command;
 use std::sync::LazyLock;
-use std::{collections::HashMap, iter::zip};
+
+/// builtin Commands and vars
+use anyhow::Result;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Documentation, InsertTextFormat};
 
 use crate::languageserver::client_support_snippet;
@@ -236,9 +238,8 @@ pub static BUILTIN_MODULE: LazyLock<Result<Vec<CompletionItem>>> = LazyLock::new
 mod tests {
     use std::iter::zip;
 
-    use crate::complete::builtin::{gen_builtin_modules, gen_builtin_variables};
-
     use super::gen_builtin_commands;
+    use crate::complete::builtin::{gen_builtin_modules, gen_builtin_variables};
     #[test]
     fn tst_regex() {
         let re = regex::Regex::new(r"-+").unwrap();

--- a/src/complete/findpackage.rs
+++ b/src/complete/findpackage.rs
@@ -1,6 +1,8 @@
-use crate::utils::CACHE_CMAKE_PACKAGES;
 use std::sync::LazyLock;
+
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Documentation};
+
+use crate::utils::CACHE_CMAKE_PACKAGES;
 
 static FIND_PACKAGE_SPACE_KEYWORDS: LazyLock<Vec<CompletionItem>> = LazyLock::new(|| {
     vec![
@@ -99,9 +101,10 @@ pub(super) fn completion_items_with_prefix(space: &str) -> Vec<CompletionItem> {
 
 #[test]
 fn test_prefix() {
+    use std::path::Path;
+
     use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
     use crate::Url;
-    use std::path::Path;
     let data = completion_items_with_prefix("bash");
 
     let data_package = CMakePackage {

--- a/src/complete/includescanner.rs
+++ b/src/complete/includescanner.rs
@@ -1,17 +1,14 @@
-use crate::{
-    consts::TREESITTER_CMAKE_LANGUAGE,
-    utils::{treehelper::PositionType, DocumentNormalize},
-};
-
-use super::getsubcomplete;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{Arc, LazyLock, Mutex};
+
 use tower_lsp::lsp_types::CompletionItem;
 
-use std::sync::{Arc, Mutex};
-
-use std::sync::LazyLock;
+use super::getsubcomplete;
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::treehelper::PositionType;
+use crate::utils::DocumentNormalize;
 
 type CacheData = HashMap<PathBuf, Vec<CompletionItem>>;
 
@@ -100,6 +97,7 @@ mod include_scan_test {
     fn test_complete_scan_1() {
         use std::fs::File;
         use std::io::Write;
+
         use tempfile::tempdir;
         use tower_lsp::lsp_types::{CompletionItemKind, Documentation};
 
@@ -191,6 +189,7 @@ endfunction()
     fn test_complete_scan_2() {
         use std::fs::File;
         use std::io::Write;
+
         use tempfile::tempdir;
         use tower_lsp::lsp_types::{CompletionItemKind, Documentation};
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
+use std::sync::LazyLock;
 
 use serde::Deserialize;
-use std::sync::LazyLock;
 
 #[derive(Deserialize, PartialEq, Eq, Debug)]
 pub struct CMakeLintConfig {

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -1,14 +1,12 @@
 use std::path::{Path, PathBuf};
 
-use crate::utils::include_is_module;
-use crate::Url;
-use tower_lsp::lsp_types::DocumentLink;
-use tower_lsp::lsp_types::Position;
-use tower_lsp::lsp_types::Range;
+use tower_lsp::lsp_types::{DocumentLink, Position, Range};
 
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-use crate::utils::{gen_module_pattern, remove_quotation_and_replace_placeholders};
-use crate::CMakeNodeKinds;
+use crate::utils::{
+    gen_module_pattern, include_is_module, remove_quotation_and_replace_placeholders,
+};
+use crate::{CMakeNodeKinds, Url};
 
 const LINK_NODE_KIND: &[&str] = &["include", "add_subdirectory"];
 
@@ -128,13 +126,14 @@ fn convert_include_cmake<P: AsRef<Path>>(name: &str, current_parent: P) -> Optio
 #[cfg(not(windows))]
 #[test]
 fn tst_document_link_search() {
-    use crate::fileapi::cache::Cache;
-    use crate::fileapi::set_cache_data;
     use std::fs;
-
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
+
+    use crate::fileapi::cache::Cache;
+    use crate::fileapi::set_cache_data;
 
     let dir = tempdir().unwrap();
 

--- a/src/fileapi.rs
+++ b/src/fileapi.rs
@@ -1,13 +1,13 @@
 pub mod cache;
 
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{LazyLock, Mutex};
+
 use cache::Cache;
 use serde::{Deserialize, Serialize};
-
 use serde_json::Value;
 use tower_lsp::lsp_types::CompletionItem;
-
-use std::sync::Mutex;
-use std::{collections::HashMap, path::Path, sync::LazyLock};
 
 static CACHE_DATA: LazyLock<Mutex<Option<Cache>>> = LazyLock::new(|| Mutex::new(None));
 
@@ -114,8 +114,7 @@ impl QueryJson {
 
 #[cfg(test)]
 mod api_test {
-    use super::Cache;
-    use super::QueryJson;
+    use super::{Cache, QueryJson};
 
     #[test]
     fn test_serde() {

--- a/src/filewatcher.rs
+++ b/src/filewatcher.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
-use std::sync::LazyLock;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
 // match like ss_DIR:PATH=ss_DIR-NOTFOUND
 static NOT_FOUND_LIBRARY: LazyLock<regex::Regex> = LazyLock::new(|| {
@@ -50,6 +49,7 @@ pub fn get_error_packages() -> Vec<String> {
 fn tst_cache_packages() {
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
     let error_cmake = dir.path().join("CMakeCache.txt");

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -1,9 +1,10 @@
 use lsp_types::{MessageType, Position, TextEdit};
 use tower_lsp::lsp_types;
 
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::treehelper::is_comment;
 use crate::utils::DocumentNormalize;
-
-use crate::{consts::TREESITTER_CMAKE_LANGUAGE, utils::treehelper::is_comment, CMakeNodeKinds};
+use crate::CMakeNodeKinds;
 
 const CLOSURE: &[&str] = &["function_def", "macro_def", "if_condition", "foreach_loop"];
 

--- a/src/gammar.rs
+++ b/src/gammar.rs
@@ -1,12 +1,12 @@
 use std::ops::Deref;
 use std::path::Path;
 use std::process::Command;
+
 use tower_lsp::lsp_types::DiagnosticSeverity;
 use tree_sitter::Point;
 
 use crate::config::{self, CMAKE_LINT_CONFIG};
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-
 use crate::utils::{include_is_module, remove_quotation_and_replace_placeholders};
 use crate::CMakeNodeKinds;
 
@@ -284,12 +284,13 @@ fn checkerror_inner<P: AsRef<Path>>(
 #[cfg(not(windows))]
 #[test]
 fn tst_gammar_check() {
-    use crate::fileapi::cache::Cache;
-    use crate::fileapi::set_cache_data;
-
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
+
+    use crate::fileapi::cache::Cache;
+    use crate::fileapi::set_cache_data;
 
     let dir = tempdir().unwrap();
 
@@ -387,6 +388,7 @@ fn scanner_include_error<P: AsRef<Path>>(path: P) -> bool {
 fn include_error_tst() {
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
 
     let dir = tempdir().unwrap();

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -1,25 +1,18 @@
-use crate::fileapi;
-use crate::utils::get_the_packagename;
-#[cfg(unix)]
-use crate::utils::packagepkgconfig::PKG_CONFIG_PACKAGES_WITHKEY;
-use crate::utils::treehelper::get_point_string;
-use crate::utils::treehelper::get_pos_type;
-use crate::utils::treehelper::PositionType;
-use crate::utils::treehelper::ToPoint;
-use crate::utils::treehelper::MESSAGE_STORAGE;
-
-#[cfg(unix)]
-use crate::utils::packagepkgconfig::PkgConfig;
-use crate::utils::CMakePackage;
-
-use crate::utils::PackageType;
-use crate::utils::CACHE_CMAKE_PACKAGES_WITHKEYS;
 use lsp_types::Position;
 /// Some tools for treesitter  to lsp_types
 use tower_lsp::lsp_types;
 use tree_sitter::Node;
 
+use crate::fileapi;
 use crate::jump::JUMP_CACHE;
+#[cfg(unix)]
+use crate::utils::packagepkgconfig::PkgConfig;
+#[cfg(unix)]
+use crate::utils::packagepkgconfig::PKG_CONFIG_PACKAGES_WITHKEY;
+use crate::utils::treehelper::{
+    get_point_string, get_pos_type, PositionType, ToPoint, MESSAGE_STORAGE,
+};
+use crate::utils::{get_the_packagename, CMakePackage, PackageType, CACHE_CMAKE_PACKAGES_WITHKEYS};
 
 #[inline]
 #[cfg(unix)]
@@ -106,8 +99,7 @@ pub async fn get_hovered_doc(location: Position, root: Node<'_>, source: &str) -
 #[tokio::test]
 async fn tst_hover() {
     use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-    use crate::utils::FindPackageFunsFake;
-    use crate::utils::FindPackageFunsTrait;
+    use crate::utils::{FindPackageFunsFake, FindPackageFunsTrait};
 
     let fake_data = FindPackageFunsFake.get_cmake_packages_withkeys();
     let fake_package = fake_data.get("bash-completion-fake").unwrap();

--- a/src/jump.rs
+++ b/src/jump.rs
@@ -1,10 +1,9 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock};
 
 use tokio::sync::Mutex;
+use tower_lsp::lsp_types::{self, Location, MessageType, Position, Range, Url};
 
 /// provide go to definition
 use crate::{
@@ -18,14 +17,12 @@ use crate::{
     },
     CMakeNodeKinds,
 };
-use std::sync::LazyLock;
-use tower_lsp::lsp_types::{self, Location, MessageType, Position, Range, Url};
 mod findpackage;
 mod include;
 mod subdirectory;
-use crate::utils::treehelper::{get_pos_type, PositionType};
-
 use tree_sitter::Node;
+
+use crate::utils::treehelper::{get_pos_type, PositionType};
 
 /// Storage the information when jump
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -585,9 +582,9 @@ mod jump_test {
     #[tokio::test]
     async fn tst_jump_subdir() {
         use std::fs;
-
         use std::fs::File;
         use std::io::Write;
+
         use tempfile::tempdir;
 
         let jump_file_src = r#"add_subdirectory(abcd_test)"#;
@@ -631,9 +628,9 @@ mod jump_test {
     #[tokio::test]
     async fn tst_jump_variable() {
         use std::fs;
-
         use std::fs::File;
         use std::io::Write;
+
         use tempfile::tempdir;
 
         let jump_file_src = r#"
@@ -710,6 +707,7 @@ add_subdirectory(abcd_test)
 fn test_sub_def() {
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
     let top_cmake_path = dir.path().join("CMakeLists.txt");

--- a/src/jump/findpackage.rs
+++ b/src/jump/findpackage.rs
@@ -1,8 +1,9 @@
 //use lsp_types::CompletionItem;
-use super::Location;
-use crate::utils::CACHE_CMAKE_PACKAGES_WITHKEYS;
 use lsp_types::Url;
 use tower_lsp::lsp_types;
+
+use super::Location;
+use crate::utils::CACHE_CMAKE_PACKAGES_WITHKEYS;
 
 pub(super) fn cmpfindpackage(input: &str) -> Option<Vec<Location>> {
     CACHE_CMAKE_PACKAGES_WITHKEYS.get(input).map(|context| {

--- a/src/jump/include.rs
+++ b/src/jump/include.rs
@@ -1,18 +1,15 @@
-use super::{gen_module_pattern, CacheDataUnit, Location};
-use lsp_types::Url;
-use std::path::{Path, PathBuf};
-use tower_lsp::lsp_types;
-
-use crate::utils::{include_is_module, DocumentNormalize};
-use crate::{consts::TREESITTER_CMAKE_LANGUAGE, utils::treehelper::PositionType};
-
-use super::getsubdef;
 use std::collections::HashMap;
 use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
 
-use std::sync::{Arc, Mutex};
+use lsp_types::Url;
+use tower_lsp::lsp_types;
 
-use std::sync::LazyLock;
+use super::{gen_module_pattern, getsubdef, CacheDataUnit, Location};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::treehelper::PositionType;
+use crate::utils::{include_is_module, DocumentNormalize};
 
 pub(super) fn cmpinclude<P: AsRef<Path>>(localpath: P, subpath: &str) -> Option<Vec<Location>> {
     let target = if !include_is_module(subpath) {
@@ -49,6 +46,7 @@ pub(super) fn cmpinclude<P: AsRef<Path>>(localpath: P, subpath: &str) -> Option<
 #[test]
 fn tst_cmp_included_cmake() {
     use std::fs::File;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
     let top_cmake = dir.path().join("CMakeLists.txt");
@@ -125,6 +123,7 @@ pub fn scanner_include_defs(
 fn scanner_include_defs_tst() {
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
     let top_cmake = dir.path().join("CMakeLists.txt");

--- a/src/jump/subdirectory.rs
+++ b/src/jump/subdirectory.rs
@@ -1,7 +1,9 @@
-use super::Location;
-use lsp_types::Url;
 use std::path::Path;
+
+use lsp_types::Url;
 use tower_lsp::lsp_types;
+
+use super::Location;
 
 pub(super) fn cmpsubdirectory<P: AsRef<Path>>(
     localpath: P,
@@ -30,8 +32,8 @@ pub(super) fn cmpsubdirectory<P: AsRef<Path>>(
 #[test]
 fn tst_cmp_subdirectory() {
     use std::fs;
-
     use std::fs::File;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
     let top_cmake = dir.path().join("CMakeLists.txt");

--- a/src/languageserver.rs
+++ b/src/languageserver.rs
@@ -1,42 +1,27 @@
 mod config;
 #[cfg(test)]
 mod test;
-use self::config::Config;
-
-use super::Backend;
-use crate::ast;
-use crate::complete;
-use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-use crate::document_link;
-use crate::fileapi;
-use crate::fileapi::DEFAULT_QUERY;
-use crate::filewatcher;
-use crate::formatting::getformat;
-use crate::gammar::checkerror;
-use crate::gammar::ErrorInformation;
-use crate::gammar::LintConfigInfo;
-use crate::hover;
-use crate::jump;
-use crate::scansubs;
-use crate::semantic_token;
-use crate::semantic_token::LEGEND_TYPE;
-use crate::utils;
-use crate::utils::did_vcpkg_project;
-use crate::utils::treehelper;
-use crate::utils::VCPKG_LIBS;
-use crate::utils::VCPKG_PREFIX;
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::{Arc, LazyLock, RwLock};
+
 use tokio::sync::Mutex;
-use tower_lsp::jsonrpc::Error as LspError;
-use tower_lsp::jsonrpc::Result;
-use tower_lsp::lsp_types;
+use tower_lsp::jsonrpc::{Error as LspError, Result};
 use tower_lsp::lsp_types::*;
-use tower_lsp::LanguageServer;
+use tower_lsp::{lsp_types, LanguageServer};
 use tree_sitter::Parser;
 
-use std::sync::LazyLock;
+use self::config::Config;
+use super::Backend;
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::fileapi::DEFAULT_QUERY;
+use crate::formatting::getformat;
+use crate::gammar::{checkerror, ErrorInformation, LintConfigInfo};
+use crate::semantic_token::LEGEND_TYPE;
+use crate::utils::{did_vcpkg_project, treehelper, VCPKG_LIBS, VCPKG_PREFIX};
+use crate::{
+    ast, complete, document_link, fileapi, filewatcher, hover, jump, scansubs, semantic_token,
+    utils,
+};
 
 pub static BUFFERS_CACHE: LazyLock<Arc<Mutex<HashMap<lsp_types::Url, String>>>> =
     LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));

--- a/src/languageserver/test.rs
+++ b/src/languageserver/test.rs
@@ -1,19 +1,19 @@
-use crate::{languageserver::Config, semantic_token::LEGEND_TYPE};
 use std::sync::Arc;
-use tokio::sync::Mutex;
-use tower::{util::ServiceExt, Service};
-use tower_lsp::{
-    jsonrpc::Request,
-    lsp_types::{
-        InitializeParams, InitializeResult, SemanticTokensFullOptions, SemanticTokensLegend,
-        SemanticTokensOptions, SemanticTokensServerCapabilities, Url, WorkDoneProgressOptions,
-    },
-    LspService,
-};
 
-use crate::BackendInitInfo;
+use tokio::sync::Mutex;
+use tower::util::ServiceExt;
+use tower::Service;
+use tower_lsp::jsonrpc::Request;
+use tower_lsp::lsp_types::{
+    InitializeParams, InitializeResult, SemanticTokensFullOptions, SemanticTokensLegend,
+    SemanticTokensOptions, SemanticTokensServerCapabilities, Url, WorkDoneProgressOptions,
+};
+use tower_lsp::LspService;
 
 use super::Backend;
+use crate::languageserver::Config;
+use crate::semantic_token::LEGEND_TYPE;
+use crate::BackendInitInfo;
 
 fn initialize_request(id: i64, init_param: InitializeParams) -> Request {
     Request::build("initialize")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,17 @@
-use ini::Ini;
 use std::io::prelude::*;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::Mutex;
-use tower_lsp::{Client, LspService, Server};
+
 //use tree_sitter::Point;
 use clap::Parser;
+use ini::Ini;
+use tokio::sync::Mutex;
+use tower_lsp::{Client, LspService, Server};
 mod treesitter_nodetypes;
 
-use treesitter_nodetypes as CMakeNodeKinds;
-
 use tokio::net::TcpListener;
+use treesitter_nodetypes as CMakeNodeKinds;
 mod ast;
 mod clapargs;
 mod complete;
@@ -30,9 +30,8 @@ mod search;
 mod semantic_token;
 mod shellcomplete;
 mod utils;
-use tower_lsp::lsp_types::Url;
-
 use clapargs::NeocmakeCli;
+use tower_lsp::lsp_types::Url;
 
 #[derive(Debug)]
 struct BackendInitInfo {
@@ -183,8 +182,9 @@ async fn main() {
             format_paths,
             hasoverride,
         } => {
-            use ignore::Walk;
             use std::path::Path;
+
+            use ignore::Walk;
             let EditConfigSetting {
                 use_space,
                 indent_size,
@@ -260,9 +260,11 @@ async fn main() {
 
 #[cfg(test)]
 mod editorconfig_test {
-    use super::{editconfig_setting_read, EditConfigSetting};
     use std::io::prelude::*;
+
     use tempfile::NamedTempFile;
+
+    use super::{editconfig_setting_read, EditConfigSetting};
     #[test]
     fn tst_editconfig_tab() {
         let mut temp_file = NamedTempFile::new().unwrap();

--- a/src/scansubs.rs
+++ b/src/scansubs.rs
@@ -1,19 +1,14 @@
-use std::{
-    collections::HashMap,
-    fmt,
-    path::{Path, PathBuf},
-};
+use std::collections::HashMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock};
 
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use std::sync::LazyLock;
 use tokio::sync::Mutex;
 
-use crate::{
-    consts::TREESITTER_CMAKE_LANGUAGE,
-    utils::{remove_quotation, remove_quotation_and_replace_placeholders},
-    CMakeNodeKinds,
-};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::{remove_quotation, remove_quotation_and_replace_placeholders};
+use crate::CMakeNodeKinds;
 
 /// NOTE: key is be included path, value is the top CMakeLists
 /// This is used to find who is on the top of the CMakeLists
@@ -199,6 +194,7 @@ async fn test_scan_sub() {
     use std::fs;
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
     let top_cmake = dir.path().join("CMakeLists.txt");
@@ -219,6 +215,7 @@ fn test_tree_dir() {
     use std::fs;
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
     let top_cmake = dir.path().join("CMakeLists.txt");

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,7 @@
+use cli_table::format::Justify;
+use cli_table::{Cell, CellStruct, Style, Table};
+
 use crate::utils::{CMakePackage, CACHE_CMAKE_PACKAGES};
-use cli_table::{format::Justify, Cell, CellStruct, Style, Table};
 pub fn search_result(tosearch: &str) -> cli_table::TableDisplay {
     let tofind = regex::Regex::new(&tosearch.to_lowercase()).unwrap();
     CACHE_CMAKE_PACKAGES

--- a/src/semantic_token.rs
+++ b/src/semantic_token.rs
@@ -1,12 +1,11 @@
-use tower_lsp::{
-    lsp_types::{SemanticToken, SemanticTokenType, SemanticTokens, SemanticTokensResult},
-    Client,
-};
-
 use std::sync::LazyLock;
 
-use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use tower_lsp::lsp_types::{
+    SemanticToken, SemanticTokenType, SemanticTokens, SemanticTokensResult,
+};
+use tower_lsp::Client;
 
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 use crate::CMakeNodeKinds;
 static NUMBERREGEX: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"^\d+(?:\.+\d*)?").unwrap());

--- a/src/shellcomplete.rs
+++ b/src/shellcomplete.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
 
-use crate::clapargs::NeocmakeCli;
-
 use clap::{Command, CommandFactory};
 use clap_complete::{generate, Generator, Shell};
+
+use crate::clapargs::NeocmakeCli;
 
 fn print_completions<G: Generator>(gen: G, cmd: &mut Command, write: &mut dyn Write) {
     generate(gen, cmd, cmd.get_name().to_string(), write)
@@ -19,10 +19,12 @@ pub fn generate_shell_completions(shell: Shell) {
 #[cfg(unix)]
 #[cfg(test)]
 mod target_test {
-    use super::{print_completions, NeocmakeCli};
+    use std::io::Cursor;
+
     use clap::CommandFactory;
     use clap_complete::Shell;
-    use std::io::Cursor;
+
+    use super::{print_completions, NeocmakeCli};
     #[test]
     fn tst_fish_is_same() {
         let mut cmd = NeocmakeCli::command();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,12 @@
 mod findpackage;
 pub mod treehelper;
-use std::{collections::HashMap, path::PathBuf, sync::LazyLock};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
 
 use crate::Url;
-use serde::{Deserialize, Serialize};
 
 static PLACE_HODER_REGEX: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"\$\{(\w+)\}").unwrap());

--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -19,24 +19,20 @@ mod packagewin;
 use packagewin as cmakepackage;
 #[cfg(target_os = "macos")]
 mod packagemac;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::LazyLock;
+
+pub use cmakepackage::*;
 #[cfg(target_os = "macos")]
 use packagemac as cmakepackage;
 use tower_lsp::lsp_types::Url;
-
-use crate::consts::TREESITTER_CMAKE_LANGUAGE;
-use crate::CMakeNodeKinds;
-
-use super::{remove_quotation, CMakePackage, CMakePackageFrom, PackageType};
-
-pub use cmakepackage::*;
 pub use vcpkg::*;
 
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    process::Command,
-    sync::LazyLock,
-};
+use super::{remove_quotation, CMakePackage, CMakePackageFrom, PackageType};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::CMakeNodeKinds;
 
 fn handle_config_package(filename: &str) -> Option<&str> {
     if let Some(tryfirst) = filename.strip_suffix("-config.cmake") {

--- a/src/utils/findpackage/packagemac.rs
+++ b/src/utils/findpackage/packagemac.rs
@@ -1,14 +1,14 @@
-use std::{collections::HashMap, fs, path::PathBuf};
-
-use crate::Url;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
 use std::sync::LazyLock;
-
-use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
 
 use super::{
     get_available_libs, get_cmake_message, get_version, handle_config_package, CMAKECONFIG,
     CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN,
 };
+use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::Url;
 
 // here is the logic of findpackage on linux
 //

--- a/src/utils/findpackage/packageunix.rs
+++ b/src/utils/findpackage/packageunix.rs
@@ -1,15 +1,14 @@
-use std::{collections::HashMap, fs, path::PathBuf};
-
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
 use std::sync::LazyLock;
-
-use crate::Url;
-
-use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
 
 use super::{
     get_available_libs, get_cmake_message, get_version, handle_config_package, CMAKECONFIG,
     CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN,
 };
+use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::Url;
 
 // here is the logic of findpackage on linux
 //
@@ -173,6 +172,7 @@ fn test_package_search() {
     use std::fs;
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
 

--- a/src/utils/findpackage/packagewin.rs
+++ b/src/utils/findpackage/packagewin.rs
@@ -1,17 +1,14 @@
-use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-use std::{
-    collections::HashMap,
-    fs,
-    path::{Path, PathBuf},
-};
-
-use crate::Url;
 
 use super::{
     get_available_libs, get_cmake_message, get_version, handle_config_package, CMAKECONFIG,
     CMAKECONFIGVERSION, CMAKEREGEX, SPECIAL_PACKAGE_PATTERN,
 };
+use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::Url;
 
 pub(super) const LIBS: [&str; 4] = ["lib", "lib32", "lib64", "share"];
 
@@ -170,6 +167,7 @@ fn test_package_search() {
     use std::fs;
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
     let dir = tempdir().unwrap();
 

--- a/src/utils/findpackage/vcpkg.rs
+++ b/src/utils/findpackage/vcpkg.rs
@@ -1,20 +1,14 @@
-use std::{
-    collections::HashMap,
-    fs,
-    path::{Path, PathBuf},
-    sync::{Arc, Mutex},
-};
-
-use crate::{utils::CMakePackageFrom, Url};
-
-use std::sync::LazyLock;
-
-use crate::utils::{CMakePackage, PackageType};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use super::{
     get_version, handle_config_package, CMAKECONFIG, CMAKECONFIGVERSION, CMAKEREGEX,
     SPECIAL_PACKAGE_PATTERN,
 };
+use crate::utils::{CMakePackage, CMakePackageFrom, PackageType};
+use crate::Url;
 
 #[inline]
 pub fn did_vcpkg_project(path: &Path) -> bool {
@@ -219,6 +213,7 @@ fn test_vcpkgpackage_search() {
     use std::fs;
     use std::fs::File;
     use std::io::Write;
+
     use tempfile::tempdir;
 
     use crate::utils::CMakePackageFrom;

--- a/src/utils/treehelper.rs
+++ b/src/utils/treehelper.rs
@@ -1,16 +1,15 @@
-use lsp_types::Position;
-use lsp_types::Range;
 use std::collections::HashMap;
 use std::iter::zip;
 use std::process::Command;
 use std::sync::LazyLock;
+
+use lsp_types::{Position, Range};
 /// Some tools for treesitter  to lsp_types
 use tower_lsp::lsp_types;
 use tree_sitter::{Node, Point};
 
-use crate::CMakeNodeKinds;
-
 use super::get_node_content;
+use crate::CMakeNodeKinds;
 
 const BLACK_POS_STRING: [&str; 5] = ["(", ")", "{", "}", "$"];
 


### PR DESCRIPTION
This will nicely group import statements together:

- First are `std` and `core`
- Then all external uses
- And lastly `crate`, `self`, and `super`