### PR TITLE
fix: install fish completions in vendor directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ prefix = get_option('prefix')
 bindir = prefix / get_option('bindir')
 datadir = prefix / get_option('datadir')
 
-fish_compeletion_dir = datadir / 'fish' / 'functions'
+fish_compeletion_dir = datadir / 'fish' / 'vendor_completions.d'
 bash_compeletion_dir = datadir / 'bash-compeletion' / 'completions'
 zsh_compeletion_dir = datadir / 'zsh' / 'site-functions'
 


### PR DESCRIPTION
Ref: https://fishshell.com/docs/current/completions.html#where-to-put-completions