### PR TITLE
Build release binaries on Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,15 @@ jobs:
                     - os: macos-13
                       target: x86_64-apple-darwin
                       artifact_name: neocmakelsp
-                    - os: ubuntu-latest
+                    # Build on Ubuntu 22.04 to link against glibc 2.35.
+                    # Ubuntu 24.04 ships glibc 2.39.
+                    - os: ubuntu-22.04
                       target: x86_64-unknown-linux-gnu
                       artifact_name: neocmakelsp
-                    - os: ubuntu-latest
+                    - os: ubuntu-22.04
                       target: x86_64-unknown-linux-musl
                       artifact_name: neocmakelsp
-                    - os: ubuntu-latest
+                    - os: ubuntu-22.04
                       target: aarch64-unknown-linux-gnu
                       artifact_name: neocmakelsp
                     - os: windows-latest
@@ -50,7 +52,7 @@ jobs:
               with:
                   targets: ${{ matrix.target }}
             - name: Install linux dependencies
-              if: ${{ matrix.os  == 'ubuntu-latest' }}
+              if: ${{ startsWith(matrix.os, 'ubuntu-') }}
               run: |
                 sudo apt update
                 sudo apt install -y musl-tools gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf


### PR DESCRIPTION
This lowers the glibc version requirement from `2.39` to `2.35`. The libc version is the main barrier of entry for using the pre-built binaries, so it should be as low as possible.
Debian 12, for instance, only ships glibc 2.36, so it cannot currently run the pre-built artifacts from the latest release.
