### PR TITLE
Make clippy happy again

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1001,7 +1001,7 @@ fn test_complete_win() {
 
     let mut parse = tree_sitter::Parser::new();
     parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let thetree = parse.parse(&file_info, None).unwrap();
+    let thetree = parse.parse(file_info, None).unwrap();
     let dir = tempdir().unwrap();
     let root_cmake = dir.path().join("CMakeList.txt");
     let mut file = File::create(&root_cmake).unwrap();

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -258,7 +258,7 @@ mod tests {
         // NOTE: In case the command fails, ignore test
         let output = include_str!("../../assets_for_test/cmake_help_commands.txt");
 
-        let output = gen_builtin_commands(&output);
+        let output = gen_builtin_commands(output);
 
         assert!(output.is_ok());
     }
@@ -268,7 +268,7 @@ mod tests {
         // NOTE: In case the command fails, ignore test
         let output = include_str!("../../assets_for_test/cmake_help_variables.txt");
 
-        let output = gen_builtin_variables(&output);
+        let output = gen_builtin_variables(output);
 
         assert!(output.is_ok());
     }
@@ -278,7 +278,7 @@ mod tests {
         // NOTE: In case the command fails, ignore test
         let output = include_str!("../../assets_for_test/cmake_help_commands.txt");
 
-        let output = gen_builtin_modules(&output);
+        let output = gen_builtin_modules(output);
 
         assert!(output.is_ok());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use dirs::config_dir;
 use serde::Deserialize;
-use std::path::PathBuf;
 
 #[derive(Deserialize, PartialEq, Eq, Debug)]
 pub struct CMakeLintConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,8 +101,8 @@ mod tests {
 
     #[test]
     fn tst_lint_config() {
-        assert_eq!((*CMAKE_LINT_CONFIG).command_upcase, "ignore");
-        assert_eq!((*CMAKE_LINT_CONFIG).enable_external_cmake_lint, false);
-        assert_eq!((*CMAKE_LINT_CONFIG).line_max_words, 80);
+        assert_eq!(CMAKE_LINT_CONFIG.command_upcase, "ignore");
+        assert!(!CMAKE_LINT_CONFIG.enable_external_cmake_lint);
+        assert_eq!(CMAKE_LINT_CONFIG.line_max_words, 80);
     }
 }

--- a/src/document_link.rs
+++ b/src/document_link.rs
@@ -229,7 +229,7 @@ add_subdirectory(abcd_test)
     let hello_cmake = dir.path().join("hello.cmake");
     File::create_new(&hello_cmake).unwrap();
     let mut top_file = File::create_new(&top_cmake).unwrap();
-    top_file.write(jump_file_src.as_bytes()).unwrap();
+    top_file.write_all(jump_file_src.as_bytes()).unwrap();
     let subdir = dir.path().join("abcd_test");
     fs::create_dir_all(&subdir).unwrap();
     let subdir_file = subdir.join("CMakeLists.txt");

--- a/src/fileapi.rs
+++ b/src/fileapi.rs
@@ -123,7 +123,7 @@ mod api_test {
 
         let final_json = include_str!("../assets_for_test/fileapi/fileapifinal.json");
 
-        let json_target: QueryJson = serde_json::from_str(&final_json).unwrap();
+        let json_target: QueryJson = serde_json::from_str(final_json).unwrap();
 
         assert_eq!(json_target, json);
 

--- a/src/gammar.rs
+++ b/src/gammar.rs
@@ -511,21 +511,15 @@ aa.cmake:56: [C0301] Line too long (143/80)
 aa.cmake:57: [C0301] Line too long (145/80)"#;
     let re = regex::Regex::new(RE_MATCH_LINT_RESULT).unwrap();
     for s in input.split('\n') {
-        match re.captures(s) {
-            Some(m) => {
-                assert!(m.name("line").is_some() && m.name("message").is_some());
-                let row = m.name("line").unwrap().as_str().parse().unwrap_or(1) - 1;
-                let column = if let Some(m) = m.name("column") {
-                    m.as_str().parse().unwrap()
-                } else {
-                    0
-                };
-                let message = m.name("message").unwrap().as_str().to_owned();
-                println!("{row}:{column} -- {message}");
-            }
-            None => {
-                assert!(false);
-            }
-        }
+        let m = re.captures(s).unwrap();
+        assert!(m.name("line").is_some() && m.name("message").is_some());
+        let row = m.name("line").unwrap().as_str().parse().unwrap_or(1) - 1;
+        let column = if let Some(m) = m.name("column") {
+            m.as_str().parse().unwrap()
+        } else {
+            0
+        };
+        let message = m.name("message").unwrap().as_str().to_owned();
+        println!("{row}:{column} -- {message}");
     }
 }

--- a/src/gammar.rs
+++ b/src/gammar.rs
@@ -462,7 +462,7 @@ fn gammer_passed_check_1() {
     let source = include_str!("../assets_for_test/gammar/include_check.cmake");
     let mut parse = tree_sitter::Parser::new();
     parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let thetree = parse.parse(&source, None).unwrap();
+    let thetree = parse.parse(source, None).unwrap();
 
     let input = thetree.root_node();
     assert_eq!(
@@ -488,7 +488,7 @@ fn gammer_passed_check_2() {
     let source = include_str!("../assets_for_test/gammar/pass_test.cmake");
     let mut parse = tree_sitter::Parser::new();
     parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let thetree = parse.parse(&source, None).unwrap();
+    let thetree = parse.parse(source, None).unwrap();
 
     assert!(
         checkerror_inner(

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -115,9 +115,9 @@ find_package(bash-completion-fake)
             character: 15,
         },
         thetree.root_node(),
-        &content,
+        content,
     )
     .await
     .unwrap();
-    assert_eq!(document, cmakepackage_document_fmt(&fake_package));
+    assert_eq!(document, cmakepackage_document_fmt(fake_package));
 }

--- a/src/jump.rs
+++ b/src/jump.rs
@@ -699,7 +699,7 @@ mod jump_test {
         let dir = tempdir().unwrap();
         let top_cmake = dir.path().join("CMakeLists.txt");
         let mut top_file = File::create_new(&top_cmake).unwrap();
-        top_file.write(jump_file_src.as_bytes()).unwrap();
+        top_file.write_all(jump_file_src.as_bytes()).unwrap();
         let subdir = dir.path().join("abcd_test");
         fs::create_dir_all(&subdir).unwrap();
         let subdir_file = subdir.join("CMakeLists.txt");
@@ -752,7 +752,7 @@ add_subdirectory(abcd_test)
         let dir = tempdir().unwrap();
         let top_cmake = dir.path().join("CMakeLists.txt");
         let mut top_file = File::create_new(&top_cmake).unwrap();
-        top_file.write(jump_file_src.as_bytes()).unwrap();
+        top_file.write_all(jump_file_src.as_bytes()).unwrap();
         let subdir = dir.path().join("abcd_test");
         fs::create_dir_all(&subdir).unwrap();
         let subdir_file = subdir.join("CMakeLists.txt");

--- a/src/jump.rs
+++ b/src/jump.rs
@@ -707,7 +707,7 @@ mod jump_test {
 
         let locations = godef_inner(
             Point { row: 0, column: 20 },
-            &jump_file_src,
+            jump_file_src,
             &top_cmake,
             true,
             false,
@@ -760,7 +760,7 @@ add_subdirectory(abcd_test)
 
         let locations = godef_inner(
             Point { row: 2, column: 18 },
-            &jump_file_src,
+            jump_file_src,
             &top_cmake,
             true,
             false,
@@ -786,7 +786,7 @@ add_subdirectory(abcd_test)
         );
         let locations_2 = godef_inner(
             Point { row: 4, column: 13 },
-            &jump_file_src,
+            jump_file_src,
             &top_cmake,
             true,
             false,

--- a/src/languageserver.rs
+++ b/src/languageserver.rs
@@ -4,6 +4,7 @@ mod test;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::exit;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, RwLock};
 
 use tokio::sync::Mutex;
@@ -26,7 +27,6 @@ use crate::{
     BackendInitInfo, ast, complete, document_link, fileapi, filewatcher, hover, jump, quick_fix,
     rename, scansubs, semantic_token, utils,
 };
-use std::sync::atomic::{AtomicBool, Ordering};
 pub static BUFFERS_CACHE: LazyLock<Arc<Mutex<HashMap<lsp_types::Uri, String>>>> =
     LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,9 @@ mod scansubs;
 mod search;
 mod semantic_token;
 mod utils;
-use clapargs::NeocmakeCli;
 use std::sync::OnceLock;
+
+use clapargs::NeocmakeCli;
 use tower_lsp::lsp_types::Uri;
 
 #[derive(Debug)]

--- a/src/quick_fix.rs
+++ b/src/quick_fix.rs
@@ -8,7 +8,8 @@ use tower_lsp::lsp_types::{
 };
 
 use crate::CMakeNodeKinds;
-use crate::{consts::TREESITTER_CMAKE_LANGUAGE, utils::treehelper::ToPosition};
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::treehelper::ToPosition;
 
 static LINT_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"((?<length>\d+)/(?<max>\d+))"#).unwrap());

--- a/src/quick_fix.rs
+++ b/src/quick_fix.rs
@@ -17,7 +17,7 @@ static LINT_REGEX: LazyLock<Regex> =
 #[test]
 fn lint_regex_text() {
     let information = "[C0301] Line too long (92/80)";
-    let caps = LINT_REGEX.captures(&information).unwrap();
+    let caps = LINT_REGEX.captures(information).unwrap();
     assert_eq!(&caps["length"], "92");
     assert_eq!(&caps["max"], "80");
 }

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, path::Path};
+use std::collections::HashMap;
+use std::path::Path;
 
 use tower_lsp::lsp_types::{Location, Position, TextEdit, Uri, WorkspaceEdit};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,8 +63,8 @@ pub fn include_is_module(file_name: &str) -> bool {
 
 #[test]
 fn ut_ismodule() {
-    assert_eq!(include_is_module("GNUInstall"), true);
-    assert_eq!(include_is_module("test.cmake"), false);
+    assert!(include_is_module("GNUInstall"));
+    assert!(!include_is_module("test.cmake"));
 }
 
 // get the content and split all argument to vector
@@ -106,7 +106,7 @@ fn get_node_content_tst_1() {
     let source = r#"findpackage(Qt5 COMPONENTS CONFIG Core Gui Widget)"#;
     let mut parse = tree_sitter::Parser::new();
     parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let tree = parse.parse(&source, None).unwrap();
+    let tree = parse.parse(source, None).unwrap();
     let input = tree.root_node();
     let argumentlist = input.child(0).unwrap().child(2).unwrap();
     let lines: Vec<&str> = source.lines().collect();
@@ -126,7 +126,7 @@ Core Gui Widget
 )"#;
     let mut parse = tree_sitter::Parser::new();
     parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let tree = parse.parse(&source, None).unwrap();
+    let tree = parse.parse(source, None).unwrap();
     let input = tree.root_node();
     let argumentlist = input.child(0).unwrap().child(2).unwrap();
     let lines: Vec<&str> = source.lines().collect();
@@ -340,7 +340,7 @@ pub fn get_the_packagename(package: &str) -> &str {
 
 #[test]
 fn package_name_check_tst() {
-    let package_names = vec!["abc", "def_LIBRARIES", "ghi_INCLUDE_DIRS"];
+    let package_names = ["abc", "def_LIBRARIES", "ghi_INCLUDE_DIRS"];
     let output: Vec<&str> = package_names
         .iter()
         .map(|name| get_the_packagename(name))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,10 @@
 mod findpackage;
 pub mod treehelper;
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::LazyLock;
-use std::{collections::HashMap, sync::Mutex};
+use std::sync::{LazyLock, Mutex};
 
 use serde::{Deserialize, Serialize};
-
 use tower_lsp::lsp_types::Uri;
 
 static PLACE_HODER_REGEX: LazyLock<regex::Regex> =

--- a/src/utils/findpackage.rs
+++ b/src/utils/findpackage.rs
@@ -45,7 +45,7 @@ fn handle_config_package(filename: &str) -> Option<&str> {
 #[test]
 fn handle_config_package_tst() {
     let test_file = "libaec-config.cmake";
-    let tst_file = handle_config_package(&test_file).unwrap();
+    let tst_file = handle_config_package(test_file).unwrap();
     assert_eq!(tst_file, "libaec");
 }
 
@@ -133,25 +133,25 @@ fn get_cmake_message() -> HashMap<String, CMakePackage> {
 fn special_package_pattern_tst() {
     let matched_pattern = "boost_atomic-1.86.0";
     assert!(SPECIAL_PACKAGE_PATTERN.is_match(matched_pattern));
-    let captures = SPECIAL_PACKAGE_PATTERN.captures(&matched_pattern).unwrap();
+    let captures = SPECIAL_PACKAGE_PATTERN.captures(matched_pattern).unwrap();
     assert_eq!(captures.get(1).unwrap().as_str(), "boost_atomic");
     assert_eq!(captures.get(2).unwrap().as_str(), "1.86.0");
 
     let matched_pattern = "QuaZip-Qt5-1.4";
     assert!(SPECIAL_PACKAGE_PATTERN.is_match(matched_pattern));
-    let captures = SPECIAL_PACKAGE_PATTERN.captures(&matched_pattern).unwrap();
+    let captures = SPECIAL_PACKAGE_PATTERN.captures(matched_pattern).unwrap();
     assert_eq!(captures.get(1).unwrap().as_str(), "QuaZip-Qt5");
     assert_eq!(captures.get(2).unwrap().as_str(), "1.4");
 
     let matched_pattern = "boost_atomic2-1.86.0";
     assert!(SPECIAL_PACKAGE_PATTERN.is_match(matched_pattern));
-    let captures = SPECIAL_PACKAGE_PATTERN.captures(&matched_pattern).unwrap();
+    let captures = SPECIAL_PACKAGE_PATTERN.captures(matched_pattern).unwrap();
     assert_eq!(captures.get(1).unwrap().as_str(), "boost_atomic2");
     assert_eq!(captures.get(2).unwrap().as_str(), "1.86.0");
 
     let matched_pattern = "mongoc-1.0";
     assert!(SPECIAL_PACKAGE_PATTERN.is_match(matched_pattern));
-    let captures = SPECIAL_PACKAGE_PATTERN.captures(&matched_pattern).unwrap();
+    let captures = SPECIAL_PACKAGE_PATTERN.captures(matched_pattern).unwrap();
     assert_eq!(captures.get(1).unwrap().as_str(), "mongoc");
     assert_eq!(captures.get(2).unwrap().as_str(), "1.0");
 

--- a/src/utils/treehelper.rs
+++ b/src/utils/treehelper.rs
@@ -420,7 +420,7 @@ fn tst_line_comment() {
 A#ss\" #sss)";
     let mut parse = tree_sitter::Parser::new();
     parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let tree = parse.parse(&source, None).unwrap();
+    let tree = parse.parse(source, None).unwrap();
     let input = tree.root_node();
     assert!(!contain_comment(Point { row: 1, column: 1 }, input));
     assert!(contain_comment(Point { row: 1, column: 8 }, input));
@@ -445,7 +445,7 @@ include("abcd/efg.cmake")
     use crate::consts::TREESITTER_CMAKE_LANGUAGE;
     let mut parse = tree_sitter::Parser::new();
     parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let tree = parse.parse(&source, None).unwrap();
+    let tree = parse.parse(source, None).unwrap();
     let input = tree.root_node();
     let source_lines = source.lines().collect();
     let pos_str_1 = get_point_string(Point { row: 2, column: 4 }, input, &source_lines).unwrap();
@@ -481,7 +481,7 @@ endmacro()
     use crate::consts::TREESITTER_CMAKE_LANGUAGE;
     let mut parse = tree_sitter::Parser::new();
     parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
-    let tree = parse.parse(&source, None).unwrap();
+    let tree = parse.parse(source, None).unwrap();
     let input = tree.root_node();
 
     assert_eq!(


### PR DESCRIPTION
Since I saw that the CI was failing on #163 and I already had the project open anyway, I decided to fix the warnings.
The CI only runs clippy on the default target. I ran it against `--all-targets` and `--all-features`.
Clippy was able to resolve most of the issues on its own.

I won't feel bad if you don't merge this and solve it differently.
