### PR TITLE
Feature: add signature_help for builtin cmake commands

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1,4 +1,4 @@
-mod builtin;
+pub mod builtin;
 mod findpackage;
 mod includescanner;
 use std::collections::HashMap;

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -15,9 +15,58 @@ use crate::languageserver::to_use_snippet;
 // // (<[^>]+>(?:\.\.\.)?)|(\.{3})|(\[.*?\])|([A-Z][A-Z_]+)
 
 // As regex can't resolve nested parameter struct, parse it manually
-fn split_parameters(command_label: &str) -> Vec<&str> {
-    let _command_label = command_label.trim();
-    todo!()
+fn split_parameters(raw_parameters_string: &str) -> Vec<&str> {
+    let parameters_char_vec: Vec<char> = raw_parameters_string.trim().chars().collect();
+    let mut i = 0;
+    let mut result = Vec::new();
+    while i < parameters_char_vec.len() {
+        let para_begin = i;
+        match parameters_char_vec[i] {
+            '.' => {
+                while let Some('.') = parameters_char_vec.get(i + 1) {
+                    i += 1;
+                }
+            }
+            bracket @ ('<' | '[') => {
+                let mut bracket_num = 1;
+                let opposite_bracket = if bracket == '<' { '>' } else { ']' };
+                while let Some(c) = parameters_char_vec.get(i + 1) {
+                    i += 1;
+                    match (c, bracket_num) {
+                        (x, _) if *x == bracket => bracket_num += 1,
+                        (x, 1) if *x == opposite_bracket => break,
+                        (x, _) if *x == opposite_bracket => bracket_num -= 1,
+                        _ => (),
+                    }
+                }
+                while let Some('.') = parameters_char_vec.get(i + 1) {
+                    i += 1;
+                }
+            }
+            'A'..='z' => {
+                while let Some(c) = parameters_char_vec.get(i + 1) {
+                    if ('A'..='z').contains(c) {
+                        i += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            ' ' | '\n' => {
+                i += 1;
+                continue;
+            }
+            _ => (),
+        }
+        if i >= parameters_char_vec.len() {
+            result.push(&raw_parameters_string[para_begin..parameters_char_vec.len()]);
+            break;
+        } else {
+            result.push(&raw_parameters_string[para_begin..=i]);
+            i += 1;
+        }
+    }
+    result
 }
 
 fn gen_builtin_command_signature_resource(
@@ -243,6 +292,49 @@ mod tests {
     use crate::complete::builtin::{gen_builtin_modules, gen_builtin_variables};
 
     #[test]
+    fn test_split_parameters() {
+        // test1 (parameters of add_executable)
+        let raw_parameters = r"<name> <options>... <sources>...";
+        let result = split_parameters(raw_parameters);
+        assert_eq!(result, vec!["<name>", "<options>...", "<sources>..."]);
+
+        // test2 (parameters of set_property)
+        let raw_parameters = r"<GLOBAL                      |
+               DIRECTORY [<dir>]           |
+               TARGET    [<target1> ...]   |
+               SOURCE    [<src1> ...]
+                         [DIRECTORY <dirs> ...]
+                         [TARGET_DIRECTORY <targets> ...] |
+               INSTALL   [<file1> ...]     |
+               TEST      [<test1> ...]
+                         [DIRECTORY <dir>] |
+               CACHE     [<entry1> ...]    >
+              [APPEND] [APPEND_STRING]
+              PROPERTY <name> [<value1> ...]";
+        let result = split_parameters(raw_parameters);
+        assert_eq!(
+            result,
+            vec![
+                r"<GLOBAL                      |
+               DIRECTORY [<dir>]           |
+               TARGET    [<target1> ...]   |
+               SOURCE    [<src1> ...]
+                         [DIRECTORY <dirs> ...]
+                         [TARGET_DIRECTORY <targets> ...] |
+               INSTALL   [<file1> ...]     |
+               TEST      [<test1> ...]
+                         [DIRECTORY <dir>] |
+               CACHE     [<entry1> ...]    >",
+                "[APPEND]",
+                "[APPEND_STRING]",
+                "PROPERTY",
+                "<name>",
+                "[<value1> ...]"
+            ]
+        );
+    }
+
+    #[test]
     fn test_regex() {
         let re = regex::Regex::new(r"-+").unwrap();
         assert!(re.is_match("---------"));
@@ -259,11 +351,55 @@ mod tests {
     fn test_cmake_command_builtin() {
         // NOTE: In case the command fails, ignore test
         // let output = include_str!("../../assets_for_test/cmake_help_commands.txt");
-
         let output = gen_builtin_commands();
-        // let output = gen_builtin_commands(output);
-
         assert!(output.is_ok());
+    }
+
+    #[test]
+    fn test_gen_builtin_command_signature_resource() {
+        let res = BUILTIN_COMMAND_SIGNATURE_RES.as_ref().unwrap();
+        let tested_command = res.get("set_property").unwrap();
+        println!(
+            "{}\n\n\n{}\n\n\n{}",
+            tested_command.signature,
+            tested_command.parameters.join("\n"),
+            tested_command.raw_doc
+        );
+        assert_eq!(
+            tested_command.signature,
+            r"set_property(<GLOBAL                      |
+               DIRECTORY [<dir>]           |
+               TARGET    [<target1> ...]   |
+               SOURCE    [<src1> ...]
+                         [DIRECTORY <dirs> ...]
+                         [TARGET_DIRECTORY <targets> ...] |
+               INSTALL   [<file1> ...]     |
+               TEST      [<test1> ...]
+                         [DIRECTORY <dir>] |
+               CACHE     [<entry1> ...]    >
+              [APPEND] [APPEND_STRING]
+              PROPERTY <name> [<value1> ...])"
+        );
+        assert_eq!(
+            tested_command.parameters,
+            vec![
+                r"<GLOBAL                      |
+               DIRECTORY [<dir>]           |
+               TARGET    [<target1> ...]   |
+               SOURCE    [<src1> ...]
+                         [DIRECTORY <dirs> ...]
+                         [TARGET_DIRECTORY <targets> ...] |
+               INSTALL   [<file1> ...]     |
+               TEST      [<test1> ...]
+                         [DIRECTORY <dir>] |
+               CACHE     [<entry1> ...]    >",
+                "[APPEND]",
+                "[APPEND_STRING]",
+                "PROPERTY",
+                "<name>",
+                "[<value1> ...]"
+            ]
+        );
     }
 
     #[test]

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -92,24 +92,24 @@ fn gen_builtin_command_signature_resource(
         })
         .collect();
     let contents: Vec<_> = re.split(raw_document).skip(1).collect();
-    keys.iter()
-        .zip(contents)
-        .filter_map(|(&key, content)| {
-            let r_match_signature = regex::Regex::new(
-                format!(r"\n\s+(?P<signature>{}\((?P<parameters>[^)]*)\))", key).as_str(),
-            )
-            .unwrap();
-            let capture = r_match_signature.captures(content)?;
-            let signature = capture.name("signature").unwrap().as_str();
-            let raw_parameters = capture.name("parameters").unwrap().as_str();
-            let parameters = split_parameters(raw_parameters);
-            Some((
-                key,
-                CommandSignatureResource::new(signature, parameters, content.trim()),
-            ))
-        })
+    let temp_iter = keys.iter().zip(contents).filter_map(|(&key, content)| {
+        let r_match_signature = regex::Regex::new(
+            format!(r"\n\s+(?P<signature>{}\((?P<parameters>[^)]*)\))", key).as_str(),
+        )
+        .unwrap();
+        let capture = r_match_signature.captures(content)?;
+        let signature = capture.name("signature").unwrap().as_str();
+        let raw_parameters = capture.name("parameters").unwrap().as_str();
+        let parameters = split_parameters(raw_parameters);
+        Some((
+            key,
+            CommandSignatureResource::new(signature, parameters, content.trim()),
+        ))
+    });
+
+    #[cfg(unix)]
+    return temp_iter
         .chain({
-            #[cfg(unix)]
             [(
                 "pkg_check_modules",
                 CommandSignatureResource::new(
@@ -119,7 +119,9 @@ fn gen_builtin_command_signature_resource(
                 ),
             )]
         })
-        .collect()
+        .collect();
+    #[cfg(windows)]
+    return temp_iter.collect();
 }
 
 fn gen_builtin_commands() -> Result<Vec<CompletionItem>> {

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -80,10 +80,7 @@ fn split_parameters(raw_parameters_string: &str) -> Vec<&str> {
 fn gen_builtin_command_signature_resource(
     raw_document: &str,
 ) -> HashMap<&str, CommandSignatureResource<'_>> {
-    // WARN: This regex is directly copied from the original gen_builtin_commands()
-    // But is might be wrong. Cause [A-z] contains [a-z]
-    // And this also contains [ \ ] ^ _ `
-    let re = regex::Regex::new(r"[a-zA-z]+\n-+").unwrap();
+    let re = regex::Regex::new(r"[a-zA-Z_]+\n-+").unwrap();
     let keys: Vec<_> = re
         .find_iter(raw_document)
         .map(|message| {
@@ -180,8 +177,7 @@ fn gen_builtin_commands() -> Result<Vec<CompletionItem>> {
 }
 
 fn gen_builtin_variables(raw_info: &str) -> Result<Vec<CompletionItem>> {
-    // WARN: same problem as the regex above
-    let re = regex::Regex::new(r"[z-zA-z]+\n-+").unwrap();
+    let re = regex::Regex::new(r"[a-zA-Z_]+\n-+").unwrap();
     let key: Vec<_> = re
         .find_iter(raw_info)
         .map(|message| {
@@ -203,8 +199,7 @@ fn gen_builtin_variables(raw_info: &str) -> Result<Vec<CompletionItem>> {
 }
 
 fn gen_builtin_modules(raw_info: &str) -> Result<Vec<CompletionItem>> {
-    // WARN: same problem as the regex above
-    let re = regex::Regex::new(r"[z-zA-z]+\n-+").unwrap();
+    let re = regex::Regex::new(r"[a-zA-Z_]+\n-+").unwrap();
     let key: Vec<_> = re
         .find_iter(raw_info)
         .map(|message| {

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -4,148 +4,127 @@ use std::process::Command;
 use std::sync::LazyLock;
 
 use anyhow::Result;
-use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Documentation, InsertTextFormat};
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
+};
 
 use crate::languageserver::to_use_snippet;
 
-fn shorter_var(arg: &str) -> String {
-    let mut shorter = arg.to_string();
-    let args = arg.split('\n').next().unwrap_or("");
-    if args.len() > 20 {
-        shorter = format!("{}...", &args[0..20]);
-    }
-    if shorter.contains(' ') {
-        shorter = format!("(arg_type: <{shorter}>)");
-    }
-    shorter = format!("<{shorter}>");
-    shorter
+// static SPIT_PRAMETER_REGEX: LazyLock<regex::Regex> =
+//     LazyLock::new(|| regex::Regex::new(r"<[^>]+>\.*").unwrap());
+// // (<[^>]+>(?:\.\.\.)?)|(\.{3})|(\[.*?\])|([A-Z][A-Z_]+)
+
+// As regex can't resolve nested parameter struct, parse it manually
+fn split_parameters(command_label: &str) -> Vec<&str> {
+    let _command_label = command_label.trim();
+    todo!()
 }
 
-fn handle_sharp_bracket(arg: &str) -> &str {
-    let left_unique = arg.starts_with("<");
-    let right_unique = arg.ends_with(">");
-    match (left_unique, right_unique) {
-        (true, true) => &arg[1..arg.len() - 1],
-        (true, false) => &arg[1..],
-        (false, true) => &arg[..arg.len() - 1],
-        (false, false) => arg,
-    }
-}
-
-fn handle_square_bracket(arg: &str) -> &str {
-    let left_unique = arg.starts_with("[");
-    let right_unique = arg.ends_with("]");
-    match (left_unique, right_unique) {
-        (true, true) => &arg[1..arg.len() - 1],
-        (true, false) => &arg[1..],
-        (false, true) => &arg[..arg.len() - 1],
-        (false, false) => arg,
-    }
-}
-
-static SNIPPET_GEN_REGEX: LazyLock<regex::Regex> =
-    LazyLock::new(|| regex::Regex::new(r"<[^>]+>").unwrap());
-
-fn convert_to_lsp_snippet(input: &str) -> String {
-    let mut result = String::new();
-    let mut last_pos = 0; // Keep track of the last match position
-    let mut i = 1;
-    for caps in SNIPPET_GEN_REGEX.captures_iter(input) {
-        if let Some(matched) = caps.get(0) {
-            let var_name_pre = matched.as_str(); // Extract captured variable
-            let var_name_pre2 = handle_sharp_bracket(var_name_pre);
-            let var_name_pre3 = handle_square_bracket(var_name_pre2);
-            let var_name = shorter_var(var_name_pre3);
-
-            // Add text before the match
-            result.push_str(&input[last_pos..matched.start()]);
-
-            // Replace the variable
-            result.push_str(&format!("${{{i}:{var_name}}}"));
-            // Update last position to after this match
-            last_pos = matched.end();
-            i += 1;
-        }
-    }
-
-    // Add remaining part of the string
-    result.push_str(&input[last_pos..]);
-
-    result
-}
-
-fn gen_builtin_commands(raw_info: &str) -> Result<Vec<CompletionItem>> {
+fn gen_builtin_command_signature_resource(
+    raw_document: &str,
+) -> HashMap<String, CommandSignatureResource<'_>> {
+    // WARN: This regex is directly copied from the original gen_builtin_commands()
+    // But is might be wrong. Cause [A-z] contains [a-z]
+    // And this also contains [ \ ] ^ _ `
     let re = regex::Regex::new(r"[a-zA-z]+\n-+").unwrap();
     let keys: Vec<_> = re
-        .find_iter(raw_info)
+        .find_iter(raw_document)
         .map(|message| {
             let temp: Vec<&str> = message.as_str().split('\n').collect();
             temp[0]
         })
         .collect();
-    let contents: Vec<_> = re.split(raw_info).collect();
-    let contents = &contents[1..].to_vec();
+    let contents: Vec<_> = re.split(raw_document).skip(1).collect();
+    keys.iter()
+        .zip(contents)
+        .flat_map(|(&key, content)| {
+            let r_match_signature = regex::Regex::new(
+                format!(r"\n\s+(?P<signature>{}\((?P<parameters>[^)]*)\))", key).as_str(),
+            )
+            .unwrap();
+            r_match_signature
+                .captures_iter(content)
+                .map(|capture| {
+                    let signature = capture.name("signature").unwrap().as_str();
+                    let raw_parameters = capture.name("parameters").unwrap().as_str();
+                    let parameters = split_parameters(raw_parameters);
+                    (
+                        key.to_string(),
+                        CommandSignatureResource::new(signature, parameters, content.trim()),
+                    )
+                })
+                .collect::<Vec<(String, CommandSignatureResource)>>()
+        })
+        .chain({
+            #[cfg(unix)]
+            [(
+                "pkg_check_modules".to_string(),
+                CommandSignatureResource::new(
+                    "pkg_check_modules()",
+                    vec![],
+                    "please findpackage PkgConfig first",
+                ),
+            )]
+        })
+        .collect()
+}
 
-    let mut completes = HashMap::new();
-    for (key, content) in keys.iter().zip(contents) {
-        let small_key = key.to_lowercase();
-        let big_key = key.to_uppercase();
-        completes.insert(small_key, content.to_string());
-        completes.insert(big_key, content.to_string());
-    }
-    #[cfg(unix)]
-    {
-        completes.insert(
-            "pkg_check_modules".to_string(),
-            "please findpackage PkgConfig first".to_string(),
-        );
-        completes.insert(
-            "PKG_CHECK_MODULES".to_string(),
-            "please findpackage PkgConfig first".to_string(),
-        );
-    }
-
+fn gen_builtin_commands() -> Result<Vec<CompletionItem>> {
+    let res = (BUILTIN_COMMAND_SIGNATURE_RES.as_ref()).unwrap();
     let client_support_snippet = to_use_snippet();
 
-    Ok(completes
+    Ok(res
         .iter()
-        .map(|(akey, message)| {
-            let mut insert_text_format = InsertTextFormat::PLAIN_TEXT;
-            let mut insert_text = akey.to_string();
-            let mut detail = "Function".to_string();
-            let s = format!(r"\n\s+(?P<signature>{akey}\([^)]*\))");
-            let r_match_signature = regex::Regex::new(s.as_str()).unwrap();
+        .flat_map(|(name, commandinfo)| {
+            let insert_text_format;
+            let detail;
+            let insert_text;
 
-            // snippets only work for lower case for now...
-            if client_support_snippet
-                && insert_text
-                    .chars()
-                    .all(|c| c.is_ascii_lowercase() || c == '_')
-            {
-                insert_text = match r_match_signature.captures(message) {
-                    Some(m) => {
-                        insert_text_format = InsertTextFormat::SNIPPET;
-                        detail += " (Snippet)";
-                        convert_to_lsp_snippet(m.name("signature").unwrap().as_str())
-                    }
-                    _ => akey.to_string(),
-                }
+            if client_support_snippet {
+                detail = "Function (Snippet)";
+                insert_text_format = InsertTextFormat::SNIPPET;
+                insert_text = format!(
+                    "{name}({})",
+                    commandinfo
+                        .parameters
+                        .iter()
+                        .enumerate()
+                        .map(|(i, s)| format!("${{{i}:{s}}}"))
+                        .collect::<Vec<String>>()
+                        .join(" ")
+                );
+            } else {
+                detail = "Function";
+                insert_text_format = InsertTextFormat::PLAIN_TEXT;
+                insert_text = name.clone() + "()";
             }
 
-            CompletionItem {
-                label: akey.to_string(),
-                kind: Some(CompletionItemKind::FUNCTION),
-                detail: Some(detail),
-                documentation: Some(Documentation::String(message.trim().to_string())),
-                insert_text: Some(insert_text),
-                insert_text_format: Some(insert_text_format),
-                ..Default::default()
-            }
+            [
+                CompletionItem {
+                    label: commandinfo.signature.to_lowercase(),
+                    kind: Some(CompletionItemKind::FUNCTION),
+                    detail: Some(detail.to_string()),
+                    documentation: commandinfo.gen_document(),
+                    insert_text: Some(insert_text.clone()),
+                    insert_text_format: Some(insert_text_format),
+                    ..Default::default()
+                },
+                CompletionItem {
+                    label: commandinfo.signature.to_uppercase(),
+                    kind: Some(CompletionItemKind::FUNCTION),
+                    detail: Some(detail.to_string()),
+                    documentation: commandinfo.gen_document(),
+                    insert_text: Some(insert_text),
+                    insert_text_format: Some(insert_text_format),
+                    ..Default::default()
+                },
+            ]
         })
         .collect())
 }
 
 fn gen_builtin_variables(raw_info: &str) -> Result<Vec<CompletionItem>> {
+    // WARN: same problem as the regex above
     let re = regex::Regex::new(r"[z-zA-z]+\n-+").unwrap();
     let key: Vec<_> = re
         .find_iter(raw_info)
@@ -168,6 +147,7 @@ fn gen_builtin_variables(raw_info: &str) -> Result<Vec<CompletionItem>> {
 }
 
 fn gen_builtin_modules(raw_info: &str) -> Result<Vec<CompletionItem>> {
+    // WARN: same problem as the regex above
     let re = regex::Regex::new(r"[z-zA-z]+\n-+").unwrap();
     let key: Vec<_> = re
         .find_iter(raw_info)
@@ -189,15 +169,54 @@ fn gen_builtin_modules(raw_info: &str) -> Result<Vec<CompletionItem>> {
         .collect())
 }
 
-/// CMake builtin commands
-pub static BUILTIN_COMMAND: LazyLock<Result<Vec<CompletionItem>>> = LazyLock::new(|| {
+pub struct CommandSignatureResource<'a> {
+    signature: &'a str,
+    parameters: Vec<&'a str>,
+    // document: Option<Documentation>,
+    raw_doc: &'a str,
+}
+
+impl<'a> CommandSignatureResource<'a> {
+    fn new(signature: &'a str, parameters: Vec<&'a str>, raw_doc: &'a str) -> Self {
+        CommandSignatureResource {
+            signature,
+            parameters,
+            raw_doc,
+        }
+    }
+
+    fn gen_document(&self) -> Option<Documentation> {
+        if self.raw_doc.is_empty() {
+            Some(Documentation::MarkupContent(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: self.raw_doc.to_string(),
+            }))
+        } else {
+            None
+        }
+    }
+}
+
+static CMAKE_COMMANDS_HELP: LazyLock<Result<String>> = LazyLock::new(|| {
     let output = Command::new("cmake")
         .arg("--help-commands")
         .output()?
         .stdout;
-    let temp = String::from_utf8_lossy(&output);
-    gen_builtin_commands(&temp)
+    Ok(String::from_utf8_lossy(&output).to_string())
 });
+/// Resource for generating builtin signatures and commands
+/// the key is command name, not signature
+pub static BUILTIN_COMMAND_SIGNATURE_RES: LazyLock<
+    Result<HashMap<String, CommandSignatureResource>>,
+> = LazyLock::new(|| {
+    Ok(gen_builtin_command_signature_resource(
+        CMAKE_COMMANDS_HELP.as_ref().unwrap(),
+    ))
+});
+
+/// CMake builtin commands
+pub static BUILTIN_COMMAND: LazyLock<Result<Vec<CompletionItem>>> =
+    LazyLock::new(gen_builtin_commands);
 
 /// cmake builtin vars
 pub static BUILTIN_VARIABLE: LazyLock<Result<Vec<CompletionItem>>> = LazyLock::new(|| {
@@ -224,23 +243,6 @@ mod tests {
     use crate::complete::builtin::{gen_builtin_modules, gen_builtin_variables};
 
     #[test]
-    fn test_convert_to_lsp_snippet() {
-        let snippet_example = r"define_property(<GLOBAL | DIRECTORY | TARGET | SOURCE |
-                  TEST | VARIABLE | CACHED_VARIABLE>
-                  PROPERTY <name> [INHERITED]
-                  [BRIEF_DOCS <brief-doc> [docs...]]
-                  [FULL_DOCS <full-doc> [docs...]]
-                  [INITIALIZE_FROM_VARIABLE <variable>])";
-        let snippet_result = convert_to_lsp_snippet(snippet_example);
-        let snippet_target = r"define_property(${1:<(arg_type: <GLOBAL | DIRECTORY |...>)>}
-                  PROPERTY ${2:<name>} [INHERITED]
-                  [BRIEF_DOCS ${3:<brief-doc>} [docs...]]
-                  [FULL_DOCS ${4:<full-doc>} [docs...]]
-                  [INITIALIZE_FROM_VARIABLE ${5:<variable>}])";
-        assert_eq!(snippet_result, snippet_target);
-    }
-
-    #[test]
     fn test_regex() {
         let re = regex::Regex::new(r"-+").unwrap();
         assert!(re.is_match("---------"));
@@ -256,9 +258,10 @@ mod tests {
     #[test]
     fn test_cmake_command_builtin() {
         // NOTE: In case the command fails, ignore test
-        let output = include_str!("../../assets_for_test/cmake_help_commands.txt");
+        // let output = include_str!("../../assets_for_test/cmake_help_commands.txt");
 
-        let output = gen_builtin_commands(output);
+        let output = gen_builtin_commands();
+        // let output = gen_builtin_commands(output);
 
         assert!(output.is_ok());
     }

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -6,6 +6,7 @@ use std::sync::LazyLock;
 use anyhow::Result;
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
+    ParameterInformation, ParameterLabel,
 };
 
 use crate::languageserver::to_use_snippet;
@@ -71,7 +72,7 @@ fn split_parameters(raw_parameters_string: &str) -> Vec<&str> {
 
 fn gen_builtin_command_signature_resource(
     raw_document: &str,
-) -> HashMap<String, CommandSignatureResource<'_>> {
+) -> HashMap<&str, CommandSignatureResource<'_>> {
     // WARN: This regex is directly copied from the original gen_builtin_commands()
     // But is might be wrong. Cause [A-z] contains [a-z]
     // And this also contains [ \ ] ^ _ `
@@ -98,16 +99,16 @@ fn gen_builtin_command_signature_resource(
                     let raw_parameters = capture.name("parameters").unwrap().as_str();
                     let parameters = split_parameters(raw_parameters);
                     (
-                        key.to_string(),
+                        key,
                         CommandSignatureResource::new(signature, parameters, content.trim()),
                     )
                 })
-                .collect::<Vec<(String, CommandSignatureResource)>>()
+                .collect::<Vec<(&str, CommandSignatureResource)>>()
         })
         .chain({
             #[cfg(unix)]
             [(
-                "pkg_check_modules".to_string(),
+                "pkg_check_modules",
                 CommandSignatureResource::new(
                     "pkg_check_modules()",
                     vec![],
@@ -128,42 +129,43 @@ fn gen_builtin_commands() -> Result<Vec<CompletionItem>> {
             let insert_text_format;
             let detail;
             let insert_text;
+            let uppercase_insert_text;
 
             if client_support_snippet {
                 detail = "Function (Snippet)";
                 insert_text_format = InsertTextFormat::SNIPPET;
-                insert_text = format!(
-                    "{name}({})",
-                    commandinfo
-                        .parameters
-                        .iter()
-                        .enumerate()
-                        .map(|(i, s)| format!("${{{i}:{s}}}"))
-                        .collect::<Vec<String>>()
-                        .join(" ")
-                );
+                let para = commandinfo
+                    .parameters
+                    .iter()
+                    .enumerate()
+                    .map(|(i, s)| format!("${{{}:{s}}}", i + 1))
+                    .collect::<Vec<String>>()
+                    .join(" ");
+                insert_text = format!("{name}({})", para);
+                uppercase_insert_text = format!("{}({})", name.to_uppercase(), para);
             } else {
                 detail = "Function";
                 insert_text_format = InsertTextFormat::PLAIN_TEXT;
-                insert_text = name.clone() + "()";
+                insert_text = name.to_string();
+                uppercase_insert_text = name.to_uppercase();
             }
 
             [
                 CompletionItem {
-                    label: commandinfo.signature.to_lowercase(),
-                    kind: Some(CompletionItemKind::FUNCTION),
-                    detail: Some(detail.to_string()),
-                    documentation: commandinfo.gen_document(),
-                    insert_text: Some(insert_text.clone()),
-                    insert_text_format: Some(insert_text_format),
-                    ..Default::default()
-                },
-                CompletionItem {
-                    label: commandinfo.signature.to_uppercase(),
+                    label: name.to_lowercase(),
                     kind: Some(CompletionItemKind::FUNCTION),
                     detail: Some(detail.to_string()),
                     documentation: commandinfo.gen_document(),
                     insert_text: Some(insert_text),
+                    insert_text_format: Some(insert_text_format),
+                    ..Default::default()
+                },
+                CompletionItem {
+                    label: name.to_uppercase(),
+                    kind: Some(CompletionItemKind::FUNCTION),
+                    detail: Some(detail.to_string()),
+                    documentation: commandinfo.gen_document(),
+                    insert_text: Some(uppercase_insert_text),
                     insert_text_format: Some(insert_text_format),
                     ..Default::default()
                 },
@@ -219,10 +221,10 @@ fn gen_builtin_modules(raw_info: &str) -> Result<Vec<CompletionItem>> {
 }
 
 pub struct CommandSignatureResource<'a> {
-    signature: &'a str,
-    parameters: Vec<&'a str>,
+    pub signature: &'a str,
+    pub parameters: Vec<&'a str>,
     // document: Option<Documentation>,
-    raw_doc: &'a str,
+    pub raw_doc: &'a str,
 }
 
 impl<'a> CommandSignatureResource<'a> {
@@ -234,14 +236,30 @@ impl<'a> CommandSignatureResource<'a> {
         }
     }
 
-    fn gen_document(&self) -> Option<Documentation> {
+    pub fn gen_document(&self) -> Option<Documentation> {
         if self.raw_doc.is_empty() {
+            None
+        } else {
             Some(Documentation::MarkupContent(MarkupContent {
                 kind: MarkupKind::Markdown,
                 value: self.raw_doc.to_string(),
             }))
-        } else {
+        }
+    }
+
+    pub fn gen_parameters(&self) -> Option<Vec<ParameterInformation>> {
+        if self.parameters.is_empty() {
             None
+        } else {
+            Some(
+                self.parameters
+                    .iter()
+                    .map(|&para| ParameterInformation {
+                        label: ParameterLabel::Simple(para.to_string()),
+                        documentation: None,
+                    })
+                    .collect(),
+            )
         }
     }
 }
@@ -256,7 +274,7 @@ static CMAKE_COMMANDS_HELP: LazyLock<Result<String>> = LazyLock::new(|| {
 /// Resource for generating builtin signatures and commands
 /// the key is command name, not signature
 pub static BUILTIN_COMMAND_SIGNATURE_RES: LazyLock<
-    Result<HashMap<String, CommandSignatureResource>>,
+    Result<HashMap<&str, CommandSignatureResource>>,
 > = LazyLock::new(|| {
     Ok(gen_builtin_command_signature_resource(
         CMAKE_COMMANDS_HELP.as_ref().unwrap(),

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -11,13 +11,10 @@ use tower_lsp::lsp_types::{
 
 use crate::languageserver::to_use_snippet;
 
-// static SPIT_PRAMETER_REGEX: LazyLock<regex::Regex> =
-//     LazyLock::new(|| regex::Regex::new(r"<[^>]+>\.*").unwrap());
-// // (<[^>]+>(?:\.\.\.)?)|(\.{3})|(\[.*?\])|([A-Z][A-Z_]+)
-
 // As regex can't resolve nested parameter struct, parse it manually
 fn split_parameters(raw_parameters_string: &str) -> Vec<&str> {
-    let parameters_char_vec: Vec<char> = raw_parameters_string.trim().chars().collect();
+    let raw_parameters_string = raw_parameters_string.trim();
+    let parameters_char_vec: Vec<char> = raw_parameters_string.chars().collect();
     let mut i = 0;
     let mut result = Vec::new();
     while i < parameters_char_vec.len() {
@@ -53,11 +50,21 @@ fn split_parameters(raw_parameters_string: &str) -> Vec<&str> {
                     }
                 }
             }
-            ' ' | '\n' => {
+            // handle comments
+            '#' => {
+                while let Some(c) = parameters_char_vec.get(i + 1) {
+                    i += 1;
+                    if *c == '\n' {
+                        break;
+                    }
+                }
                 i += 1;
                 continue;
             }
-            _ => (),
+            _ => {
+                i += 1;
+                continue;
+            }
         }
         if i >= parameters_char_vec.len() {
             result.push(&raw_parameters_string[para_begin..parameters_char_vec.len()]);
@@ -87,23 +94,19 @@ fn gen_builtin_command_signature_resource(
     let contents: Vec<_> = re.split(raw_document).skip(1).collect();
     keys.iter()
         .zip(contents)
-        .flat_map(|(&key, content)| {
+        .filter_map(|(&key, content)| {
             let r_match_signature = regex::Regex::new(
                 format!(r"\n\s+(?P<signature>{}\((?P<parameters>[^)]*)\))", key).as_str(),
             )
             .unwrap();
-            r_match_signature
-                .captures_iter(content)
-                .map(|capture| {
-                    let signature = capture.name("signature").unwrap().as_str();
-                    let raw_parameters = capture.name("parameters").unwrap().as_str();
-                    let parameters = split_parameters(raw_parameters);
-                    (
-                        key,
-                        CommandSignatureResource::new(signature, parameters, content.trim()),
-                    )
-                })
-                .collect::<Vec<(&str, CommandSignatureResource)>>()
+            let capture = r_match_signature.captures(content)?;
+            let signature = capture.name("signature").unwrap().as_str();
+            let raw_parameters = capture.name("parameters").unwrap().as_str();
+            let parameters = split_parameters(raw_parameters);
+            Some((
+                key,
+                CommandSignatureResource::new(signature, parameters, content.trim()),
+            ))
         })
         .chain({
             #[cfg(unix)]
@@ -348,6 +351,25 @@ mod tests {
                 "PROPERTY",
                 "<name>",
                 "[<value1> ...]"
+            ]
+        );
+
+        // test something with comments
+        let raw_parameters = r"<variable>
+               [CONFIGURATION <config>]
+               [PARALLEL_LEVEL <parallel>]
+               [TARGET <target>]
+               [PROJECT_NAME <projname>] # legacy, causes warning
+              ";
+        let result = split_parameters(raw_parameters);
+        assert_eq!(
+            result,
+            vec![
+                "<variable>",
+                "[CONFIGURATION <config>]",
+                "[PARALLEL_LEVEL <parallel>]",
+                "[TARGET <target>]",
+                "[PROJECT_NAME <projname>]"
             ]
         );
     }

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -123,7 +123,7 @@ fn gen_builtin_command_signature_resource(
 }
 
 fn gen_builtin_commands() -> Result<Vec<CompletionItem>> {
-    let res = (BUILTIN_COMMAND_SIGNATURE_RES.as_ref()).unwrap();
+    let res = &*BUILTIN_COMMAND_SIGNATURE_RES;
     let client_support_snippet = to_use_snippet();
 
     Ok(res
@@ -276,13 +276,8 @@ static CMAKE_COMMANDS_HELP: LazyLock<Result<String>> = LazyLock::new(|| {
 });
 /// Resource for generating builtin signatures and commands
 /// the key is command name, not signature
-pub static BUILTIN_COMMAND_SIGNATURE_RES: LazyLock<
-    Result<HashMap<&str, CommandSignatureResource>>,
-> = LazyLock::new(|| {
-    Ok(gen_builtin_command_signature_resource(
-        CMAKE_COMMANDS_HELP.as_ref().unwrap(),
-    ))
-});
+pub static BUILTIN_COMMAND_SIGNATURE_RES: LazyLock<HashMap<&str, CommandSignatureResource>> =
+    LazyLock::new(|| gen_builtin_command_signature_resource(CMAKE_COMMANDS_HELP.as_ref().unwrap()));
 
 /// CMake builtin commands
 pub static BUILTIN_COMMAND: LazyLock<Result<Vec<CompletionItem>>> =
@@ -397,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_gen_builtin_command_signature_resource() {
-        let res = BUILTIN_COMMAND_SIGNATURE_RES.as_ref().unwrap();
+        let res = &*BUILTIN_COMMAND_SIGNATURE_RES;
         let tested_command = res.get("set_property").unwrap();
         println!(
             "{}\n\n\n{}\n\n\n{}",

--- a/src/languageserver.rs
+++ b/src/languageserver.rs
@@ -11,20 +11,18 @@ use dashmap::DashMap;
 use tower_lsp::jsonrpc::{Error as LspError, Result};
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, lsp_types};
-use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
+use tree_sitter::Parser;
 
 use self::config::Config;
 use super::Backend;
-use crate::CMakeNodeKinds;
-use crate::complete::builtin::BUILTIN_COMMAND_SIGNATURE_RES;
 use crate::config::CONFIG;
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 use crate::fileapi::DEFAULT_QUERY;
 use crate::formatting::getformat;
 use crate::grammar::{ErrorInformation, LintConfigInfo, checkerror};
 use crate::semantic_token::LEGEND_TYPE;
-use crate::utils::query::NORMAL_COMMAND_QUERY;
-use crate::utils::treehelper::{ToPoint, ToPosition};
+use crate::signature_help::get_signature_help;
+use crate::utils::treehelper::ToPosition;
 use crate::utils::{VCPKG_LIBS, VCPKG_PREFIX, did_vcpkg_project, treehelper};
 use crate::{
     BackendInitInfo, complete, document_link, document_symbol, fileapi, filewatcher, hover, jump,
@@ -810,39 +808,11 @@ impl LanguageServer for Backend {
         let Some(text) = self.documents.get(&uri) else {
             return Ok(None);
         };
-
         let mut parse = Parser::new();
         parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
         let tree = parse.parse(text.value(), None).unwrap();
 
-        let query_cmd = Query::new(&TREESITTER_CMAKE_LANGUAGE, NORMAL_COMMAND_QUERY).unwrap();
-        let mut query_cursor = QueryCursor::new();
-        query_cursor.set_point_range(position.to_point()..position.to_point());
-        let mut match_cmd = query_cursor.matches(&query_cmd, tree.root_node(), text.as_bytes());
-        while let Some(m) = match_cmd.next() {
-            let node = m.nodes_for_capture_index(0).next().unwrap();
-            let Some(identifier) = node.child(0) else {
-                continue;
-            };
-            if identifier.kind() != CMakeNodeKinds::IDENTIFIER {
-                continue;
-            }
-            if let Some(command) =
-                BUILTIN_COMMAND_SIGNATURE_RES.get(identifier.utf8_text(text.as_bytes()).unwrap())
-            {
-                return Ok(Some(SignatureHelp {
-                    signatures: vec![SignatureInformation {
-                        label: command.signature.to_string(),
-                        documentation: command.gen_document(),
-                        parameters: command.gen_parameters(),
-                        active_parameter: None,
-                    }],
-                    active_signature: None,
-                    active_parameter: None,
-                }));
-            }
-        }
-        Ok(None)
+        Ok(get_signature_help(position, tree.root_node(), &text))
     }
 
     async fn document_symbol(

--- a/src/languageserver.rs
+++ b/src/languageserver.rs
@@ -277,16 +277,9 @@ impl LanguageServer for Backend {
                     completion_item: None,
                 }),
                 signature_help_provider: Some(SignatureHelpOptions {
-                    trigger_characters: Some(vec![
-                        String::from("("),
-                        String::from(" "),
-                        String::from("\n"),
-                    ]),
+                    trigger_characters: Some(vec!["(".into()]),
                     retrigger_characters: None,
-                    // retrigger_characters: Some(vec![String::from(" ")]),
-                    work_done_progress_options: WorkDoneProgressOptions {
-                        work_done_progress: None,
-                    },
+                    work_done_progress_options: Default::default(),
                 }),
                 document_symbol_provider: Some(OneOf::Left(true)),
                 definition_provider: Some(OneOf::Left(true)),

--- a/src/languageserver.rs
+++ b/src/languageserver.rs
@@ -11,10 +11,11 @@ use dashmap::DashMap;
 use tower_lsp::jsonrpc::{Error as LspError, Result};
 use tower_lsp::lsp_types::*;
 use tower_lsp::{LanguageServer, lsp_types};
-use tree_sitter::Parser;
+use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
 
 use self::config::Config;
 use super::Backend;
+use crate::CMakeNodeKinds;
 use crate::complete::builtin::BUILTIN_COMMAND_SIGNATURE_RES;
 use crate::config::CONFIG;
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
@@ -22,11 +23,12 @@ use crate::fileapi::DEFAULT_QUERY;
 use crate::formatting::getformat;
 use crate::grammar::{ErrorInformation, LintConfigInfo, checkerror};
 use crate::semantic_token::LEGEND_TYPE;
+use crate::utils::query::NORMAL_COMMAND_QUERY;
 use crate::utils::treehelper::{ToPoint, ToPosition};
 use crate::utils::{VCPKG_LIBS, VCPKG_PREFIX, did_vcpkg_project, treehelper};
 use crate::{
-    BackendInitInfo, CMakeNodeKinds, complete, document_link, document_symbol, fileapi,
-    filewatcher, hover, jump, quick_fix, rename, scansubs, semantic_token, utils,
+    BackendInitInfo, complete, document_link, document_symbol, fileapi, filewatcher, hover, jump,
+    quick_fix, rename, scansubs, semantic_token, utils,
 };
 
 static CLIENT_CAPABILITIES: RwLock<Option<TextDocumentClientCapabilities>> = RwLock::new(None);
@@ -808,25 +810,26 @@ impl LanguageServer for Backend {
         let Some(text) = self.documents.get(&uri) else {
             return Ok(None);
         };
+
         let mut parse = Parser::new();
         parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
         let tree = parse.parse(text.value(), None).unwrap();
 
-        let mut node = tree
-            .root_node()
-            .descendant_for_point_range(position.to_point(), position.to_point());
-        let Ok(res) = BUILTIN_COMMAND_SIGNATURE_RES.as_ref() else {
-            return Ok(None);
-        };
-
-        while let Some(current) = node {
-            if current.kind() == CMakeNodeKinds::NORMAL_COMMAND
-                && let Some(identifier_node) = current.child(0)
+        let query_cmd = Query::new(&TREESITTER_CMAKE_LANGUAGE, NORMAL_COMMAND_QUERY).unwrap();
+        let mut query_cursor = QueryCursor::new();
+        query_cursor.set_point_range(position.to_point()..position.to_point());
+        let mut match_cmd = query_cursor.matches(&query_cmd, tree.root_node(), text.as_bytes());
+        while let Some(m) = match_cmd.next() {
+            let node = m.nodes_for_capture_index(0).next().unwrap();
+            let Some(identifier) = node.child(0) else {
+                continue;
+            };
+            if identifier.kind() != CMakeNodeKinds::IDENTIFIER {
+                continue;
+            }
+            if let Some(command) =
+                BUILTIN_COMMAND_SIGNATURE_RES.get(identifier.utf8_text(text.as_bytes()).unwrap())
             {
-                let command_name_at_pos = &text.value()[identifier_node.byte_range()];
-                let Some(command) = res.get(command_name_at_pos) else {
-                    return Ok(None);
-                };
                 return Ok(Some(SignatureHelp {
                     signatures: vec![SignatureInformation {
                         label: command.signature.to_string(),
@@ -838,7 +841,6 @@ impl LanguageServer for Backend {
                     active_parameter: None,
                 }));
             }
-            node = current.parent();
         }
         Ok(None)
     }

--- a/src/languageserver.rs
+++ b/src/languageserver.rs
@@ -15,17 +15,18 @@ use tree_sitter::Parser;
 
 use self::config::Config;
 use super::Backend;
+use crate::complete::builtin::BUILTIN_COMMAND_SIGNATURE_RES;
 use crate::config::CONFIG;
 use crate::consts::TREESITTER_CMAKE_LANGUAGE;
 use crate::fileapi::DEFAULT_QUERY;
 use crate::formatting::getformat;
 use crate::grammar::{ErrorInformation, LintConfigInfo, checkerror};
 use crate::semantic_token::LEGEND_TYPE;
-use crate::utils::treehelper::ToPosition;
+use crate::utils::treehelper::{ToPoint, ToPosition};
 use crate::utils::{VCPKG_LIBS, VCPKG_PREFIX, did_vcpkg_project, treehelper};
 use crate::{
-    BackendInitInfo, complete, document_link, document_symbol, fileapi, filewatcher, hover, jump,
-    quick_fix, rename, scansubs, semantic_token, utils,
+    BackendInitInfo, CMakeNodeKinds, complete, document_link, document_symbol, fileapi,
+    filewatcher, hover, jump, quick_fix, rename, scansubs, semantic_token, utils,
 };
 
 static CLIENT_CAPABILITIES: RwLock<Option<TextDocumentClientCapabilities>> = RwLock::new(None);
@@ -274,6 +275,18 @@ impl LanguageServer for Backend {
                     work_done_progress_options: Default::default(),
                     all_commit_characters: None,
                     completion_item: None,
+                }),
+                signature_help_provider: Some(SignatureHelpOptions {
+                    trigger_characters: Some(vec![
+                        String::from("("),
+                        String::from(" "),
+                        String::from("\n"),
+                    ]),
+                    retrigger_characters: None,
+                    // retrigger_characters: Some(vec![String::from(" ")]),
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: None,
+                    },
                 }),
                 document_symbol_provider: Some(OneOf::Left(true)),
                 definition_provider: Some(OneOf::Left(true)),
@@ -794,6 +807,47 @@ impl LanguageServer for Backend {
             }))),
             None => Ok(None),
         }
+    }
+
+    async fn signature_help(&self, params: SignatureHelpParams) -> Result<Option<SignatureHelp>> {
+        let position = params.text_document_position_params.position;
+        let uri = params.text_document_position_params.text_document.uri;
+        let Some(text) = self.documents.get(&uri) else {
+            return Ok(None);
+        };
+        let mut parse = Parser::new();
+        parse.set_language(&TREESITTER_CMAKE_LANGUAGE).unwrap();
+        let tree = parse.parse(text.value(), None).unwrap();
+
+        let mut node = tree
+            .root_node()
+            .descendant_for_point_range(position.to_point(), position.to_point());
+        let Ok(res) = BUILTIN_COMMAND_SIGNATURE_RES.as_ref() else {
+            return Ok(None);
+        };
+
+        while let Some(current) = node {
+            if current.kind() == CMakeNodeKinds::NORMAL_COMMAND
+                && let Some(identifier_node) = current.child(0)
+            {
+                let command_name_at_pos = &text.value()[identifier_node.byte_range()];
+                let Some(command) = res.get(command_name_at_pos) else {
+                    return Ok(None);
+                };
+                return Ok(Some(SignatureHelp {
+                    signatures: vec![SignatureInformation {
+                        label: command.signature.to_string(),
+                        documentation: command.gen_document(),
+                        parameters: command.gen_parameters(),
+                        active_parameter: None,
+                    }],
+                    active_signature: None,
+                    active_parameter: None,
+                }));
+            }
+            node = current.parent();
+        }
+        Ok(None)
     }
 
     async fn document_symbol(

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod rename;
 mod scansubs;
 mod search;
 mod semantic_token;
+mod signature_help;
 mod utils;
 use std::sync::OnceLock;
 

--- a/src/signature_help.rs
+++ b/src/signature_help.rs
@@ -1,0 +1,42 @@
+use tower_lsp::lsp_types::{Position, SignatureHelp, SignatureInformation};
+use tree_sitter::{Node, Query, QueryCursor, StreamingIterator};
+
+use crate::CMakeNodeKinds;
+use crate::complete::builtin::BUILTIN_COMMAND_SIGNATURE_RES;
+use crate::consts::TREESITTER_CMAKE_LANGUAGE;
+use crate::utils::{query::NORMAL_COMMAND_QUERY, treehelper::ToPoint};
+
+pub fn get_signature_help(
+    location: Position,
+    root: Node<'_>,
+    source: &str,
+) -> Option<SignatureHelp> {
+    let query_cmd = Query::new(&TREESITTER_CMAKE_LANGUAGE, NORMAL_COMMAND_QUERY).unwrap();
+    let mut query_cursor = QueryCursor::new();
+    query_cursor.set_point_range(location.to_point()..location.to_point());
+    let mut match_cmd = query_cursor.matches(&query_cmd, root, source.as_bytes());
+    while let Some(m) = match_cmd.next() {
+        let node = m.nodes_for_capture_index(0).next().unwrap();
+        let Some(identifier) = node.child(0) else {
+            continue;
+        };
+        if identifier.kind() != CMakeNodeKinds::IDENTIFIER {
+            continue;
+        }
+        if let Some(command) =
+            BUILTIN_COMMAND_SIGNATURE_RES.get(identifier.utf8_text(source.as_bytes()).unwrap())
+        {
+            return Some(SignatureHelp {
+                signatures: vec![SignatureInformation {
+                    label: command.signature.to_string(),
+                    documentation: command.gen_document(),
+                    parameters: command.gen_parameters(),
+                    active_parameter: None,
+                }],
+                active_signature: None,
+                active_parameter: None,
+            });
+        }
+    }
+    None
+}

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -24,7 +24,7 @@ const FUNCTION_QUERY: &str = r"(
        (argument_list ((argument)*) @args))
 )";
 
-const NORMAL_COMMAND_QUERY: &str = r"
+pub const NORMAL_COMMAND_QUERY: &str = r"
 (
     (normal_command) @normal_command
 )


### PR DESCRIPTION
related issue: [#241](https://github.com/neocmakelsp/neocmakelsp/issues/241#issuecomment-3895223969)

### Changes:
- Refactor some function in `src/complete/builtin.rs` to reuse parsed cmake documents
- Add `signature_help` function in `languageserver.rs` and its capability declaration
- Change `mod builtin;` in `complete.rs` into `pub` as it's used in `lanuageserver.rs`
- Change document of completions into `Markdown` format

***Note: The 3 regular expressions in `src/complete/buitin.rs` might be incorrect. I marked them in the code but haven't changed them***

### Issue:
As cmake use whitespaces to separate parameters, so we want editor to trigger signature help when insert a space(Declare `trigger_characters`  in capabilities). However, neovim don't treat it as a trigger character and won't send requests when typing a space. Thus I added the following autocmds as a workaround:
(And also are there any ways to add autocmds if the user configures lsp via `mason`?)
```lua
-- neocmakelsp `signature_help` hack
-- check is there an ) after this character in the current line and there are only spaces between them
local function check_condition()
    local _, col = unpack(vim.api.nvim_win_get_cursor(0))
    local line = vim.api.nvim_get_current_line()
    local i = col + 1
    while i <= #line do
        local c = line:sub(i, i)
        if c == ")" then
            return true
        elseif c:match("%s") then
            i = i + 1
        else
            return false
        end
    end
    return false
end
-- check whether send signature_help request when inserting new text
vim.api.nvim_create_autocmd("InsertCharPre", {
    pattern = { "CMakeLists.txt", "*.cmake" },
    callback = function()
        local char = vim.v.char
        if (char == " " or char == "\n") and check_condition() then
            vim.defer_fn(vim.lsp.buf.signature_help, 20)
        end
    end,
})
-- check whether send signature_help request when enter insert mode
vim.api.nvim_create_autocmd("InsertEnter", {
    pattern = { "CMakeLists.txt", "*.cmake" },
    callback = function()
        if check_condition() then
            vim.defer_fn(vim.lsp.buf.signature_help, 30)
        end
    end,
})
```

<img width="1635" height="726" alt="图片" src="https://github.com/user-attachments/assets/c2e24310-b8ab-443e-a211-06eddc428e80" />
