### PR TITLE
fix(ci): bump codecov version

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           RUST_LOG: cargo_tarpaulin=error
       - name: Upload codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           fail_ci_if_error: true
         env:


### PR DESCRIPTION
Codecov PGP keys got rotated, v6.0.1 was still using the old keys.

[Release notes for reference.](https://github.com/codecov/codecov-action/releases#release-v6.0.2)