### PR TITLE
fix: send null version in publishDiagnostics

### DIFF
--- a/src/languageserver.rs
+++ b/src/languageserver.rs
@@ -145,7 +145,7 @@ impl Backend {
                 pusheddiagnoses.push(diagnose);
             }
             self.client
-                .publish_diagnostics(uri, pusheddiagnoses, Some(1))
+                .publish_diagnostics(uri, pusheddiagnoses, None)
                 .await;
         } else {
             self.client.publish_diagnostics(uri, vec![], None).await;


### PR DESCRIPTION
**TL;DR:** `publishDiagnostics` sends a hardcoded `version=1` that neocmakelsp doesn't actually track, causing strict clients (eglot, Helix) to drop diagnostics. Send `None` to omit the field, matching the empty-diagnostics path and the LSP spec's optional `version` semantics.

## Problem

neocmakelsp hardcodes `version=1` in
`publishDiagnostics` (src/languageserver.rs:148)
even though the document version is never tracked; It is discarded in both `did_open` and `did_change_inner`.

The `PublishDiagnosticsParams.version` field is optional in the LSP spec (`version?: integer`, since 3.15.0). Clients only interpret it if they advertise `publishDiagnostics.versionSupport: true`.

The hardcoded version causes strict LSP clients that enforce version matching to drop all non-empty diagnostics. For example, eglot (Emacs) checks:

    (if (and version (/= version eglot--docver))
        (cl-return-from eglot--flymake-handle-push))

Since eglot's docver starts at 0 on didOpen and increments on each edit, the hardcoded 1 only mathces by accident on the first edit. Diagnostics are dropped on file open and after the second edit onward.

## Fix

Change `Some(1)` to `None`, omitting the version field entirely so `None` produces no `version` key in the JSON.

This is appropriate because neocmakelsp does not track document versions. Cleints that don't advertise `versionSupport` ignore the field regardless. Clients that do advertise it treat an absent version as "assume current," which is correct here since neocmakelsp computes diagnostics synchronously inside did_open/did_change/did_save handlers with no async race.

The empty-diagnostics path (else block, line 150) already sends None. This makes the non-empty path consistent and conformant.