### PR TITLE
cache builtin commands in order to speed up init time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +124,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -131,6 +152,19 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -232,6 +266,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -542,6 +582,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +773,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +851,7 @@ version = "0.10.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "clap",
  "clap_complete",
  "cli-table",
@@ -809,6 +885,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1578,6 +1663,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,10 +1751,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.89.0"
 
 [dependencies]
 anyhow = "1.0.102"
+chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.0", features = ["derive"] }
 clap_complete = { version = "4.6.0", features = ["unstable-dynamic"] }
 cli-table = "0.5.0"

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -1,15 +1,15 @@
+use std::collections::HashMap;
 use std::iter::zip;
 use std::process::Command;
 use std::sync::LazyLock;
-use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::Result;
-use etcetera::BaseStrategy;
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
     ParameterInformation, ParameterInformationLabel,
 };
 
+use crate::utils::BUILTIN_MODULE_CACHED_DIR;
 use crate::{languageserver::to_use_snippet, utils::CachedCompleteItems};
 
 // As regex can't resolve nested parameter struct, parse it manually
@@ -145,7 +145,7 @@ fn gen_builtin_commands() -> Vec<CompletionItem> {
         && let Some(cache_completes) = CachedCompleteItems::read(config_file)
         && !cache_completes.need_update()
     {
-        return cache_completes.completions;
+        return cache_completes.data;
     }
 
     let res = &*BUILTIN_COMMAND_SIGNATURE_RES;
@@ -218,7 +218,7 @@ fn get_builtin_variables() -> Result<Vec<CompletionItem>> {
         && let Some(cache_completes) = CachedCompleteItems::read(config_file)
         && !cache_completes.need_update()
     {
-        return Ok(cache_completes.completions);
+        return Ok(cache_completes.data);
     }
     let output = Command::new("cmake")
         .arg("--help-variables")
@@ -371,12 +371,6 @@ pub static BUILTIN_VARIABLE: LazyLock<Result<Vec<CompletionItem>>> =
 pub static BUILTIN_MODULE: LazyLock<Result<Vec<CompletionItem>>> =
     LazyLock::new(get_builtin_modules);
 
-pub static BUILTIN_MODULE_CACHED_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
-    let strategy = etcetera::choose_base_strategy().ok()?;
-    let cache_dir = strategy.cache_dir();
-    Some(cache_dir.join("neocmakelsp"))
-});
-
 fn get_builtin_modules() -> Result<Vec<CompletionItem>> {
     if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
@@ -385,7 +379,7 @@ fn get_builtin_modules() -> Result<Vec<CompletionItem>> {
         && let Some(cache_completes) = CachedCompleteItems::read(config_file)
         && !cache_completes.need_update()
     {
-        return Ok(cache_completes.completions);
+        return Ok(cache_completes.data);
     }
     let output = Command::new("cmake").arg("--help-modules").output()?.stdout;
     let temp = String::from_utf8_lossy(&output);

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -126,17 +126,17 @@ fn gen_builtin_command_signature_resource(
     return temp_iter.collect();
 }
 
-fn builtin_command_cached_file<'a>(client_support_snippet: bool) -> &'a str {
+fn builtin_commands_cached_file<'a>(client_support_snippet: bool) -> &'a str {
     if client_support_snippet {
-        "builtin_command.json"
+        "builtin_commands.json"
     } else {
-        "builtin_command_snippet.json"
+        "builtin_commands_snippet.json"
     }
 }
 
 fn gen_builtin_commands() -> Vec<CompletionItem> {
     let client_support_snippet = to_use_snippet();
-    let cached_file = builtin_command_cached_file(client_support_snippet);
+    let cached_file = builtin_commands_cached_file(client_support_snippet);
 
     if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -1,15 +1,16 @@
-use std::collections::HashMap;
 use std::iter::zip;
 use std::process::Command;
 use std::sync::LazyLock;
+use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::Result;
+use etcetera::BaseStrategy;
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
     ParameterInformation, ParameterInformationLabel,
 };
 
-use crate::languageserver::to_use_snippet;
+use crate::{languageserver::to_use_snippet, utils::CachedCompleteItems};
 
 // As regex can't resolve nested parameter struct, parse it manually
 fn split_parameters(raw_parameters_string: &str) -> Vec<&str> {
@@ -125,11 +126,32 @@ fn gen_builtin_command_signature_resource(
     return temp_iter.collect();
 }
 
-fn gen_builtin_commands() -> Vec<CompletionItem> {
-    let res = &*BUILTIN_COMMAND_SIGNATURE_RES;
-    let client_support_snippet = to_use_snippet();
+fn builtin_command_cached_file<'a>(client_support_snippet: bool) -> &'a str {
+    if client_support_snippet {
+        "builtin_command.json"
+    } else {
+        "builtin_command_snippet.json"
+    }
+}
 
-    res.iter()
+fn gen_builtin_commands() -> Vec<CompletionItem> {
+    let client_support_snippet = to_use_snippet();
+    let cached_file = builtin_command_cached_file(client_support_snippet);
+
+    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+        && std::fs::create_dir_all(cache_dir).is_ok()
+        && let config_file = cache_dir.join(cached_file)
+        && config_file.exists()
+        && let Some(cache_completes) = CachedCompleteItems::read(config_file)
+        && !cache_completes.need_update()
+    {
+        return cache_completes.completions;
+    }
+
+    let res = &*BUILTIN_COMMAND_SIGNATURE_RES;
+
+    let commands: Vec<CompletionItem> = res
+        .iter()
         .flat_map(|(name, commandinfo)| {
             let insert_text_format;
             let detail;
@@ -176,7 +198,43 @@ fn gen_builtin_commands() -> Vec<CompletionItem> {
                 },
             ]
         })
-        .collect()
+        .collect();
+    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+        && std::fs::create_dir_all(cache_dir).is_ok()
+        && let config_file = cache_dir.join(cached_file)
+        && let cached = CachedCompleteItems::new(commands.clone())
+        && let Ok(data) = serde_json::to_string_pretty(&cached)
+    {
+        std::fs::write(config_file, data).ok();
+    }
+    commands
+}
+
+fn get_builtin_variables() -> Result<Vec<CompletionItem>> {
+    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+        && std::fs::create_dir_all(cache_dir).is_ok()
+        && let config_file = cache_dir.join("builtin_variable_cache.json")
+        && config_file.exists()
+        && let Some(cache_completes) = CachedCompleteItems::read(config_file)
+        && !cache_completes.need_update()
+    {
+        return Ok(cache_completes.completions);
+    }
+    let output = Command::new("cmake")
+        .arg("--help-variables")
+        .output()?
+        .stdout;
+    let temp = String::from_utf8_lossy(&output);
+    let variables = gen_builtin_variables(&temp);
+    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+        && std::fs::create_dir_all(cache_dir).is_ok()
+        && let config_file = cache_dir.join("builtin_variable_cache.json")
+        && let cached = CachedCompleteItems::new(variables.clone())
+        && let Ok(data) = serde_json::to_string_pretty(&cached)
+    {
+        std::fs::write(config_file, data).ok();
+    }
+    Ok(variables)
 }
 
 fn gen_builtin_variables(raw_info: &str) -> Vec<CompletionItem> {
@@ -306,21 +364,44 @@ pub static BUILTIN_COMMAND_SIGNATURE_RES: LazyLock<HashMap<&str, CommandSignatur
 pub static BUILTIN_COMMAND: LazyLock<Vec<CompletionItem>> = LazyLock::new(gen_builtin_commands);
 
 /// cmake builtin vars
-pub static BUILTIN_VARIABLE: LazyLock<Result<Vec<CompletionItem>>> = LazyLock::new(|| {
-    let output = Command::new("cmake")
-        .arg("--help-variables")
-        .output()?
-        .stdout;
-    let temp = String::from_utf8_lossy(&output);
-    Ok(gen_builtin_variables(&temp))
-});
+pub static BUILTIN_VARIABLE: LazyLock<Result<Vec<CompletionItem>>> =
+    LazyLock::new(get_builtin_variables);
 
 /// Cmake builtin modules
-pub static BUILTIN_MODULE: LazyLock<Result<Vec<CompletionItem>>> = LazyLock::new(|| {
+pub static BUILTIN_MODULE: LazyLock<Result<Vec<CompletionItem>>> =
+    LazyLock::new(get_builtin_modules);
+
+pub static BUILTIN_MODULE_CACHED_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
+    let strategy = etcetera::choose_base_strategy().ok()?;
+    let cache_dir = strategy.cache_dir();
+    Some(cache_dir.join("neocmakelsp"))
+});
+
+fn get_builtin_modules() -> Result<Vec<CompletionItem>> {
+    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+        && std::fs::create_dir_all(cache_dir).is_ok()
+        && let config_file = cache_dir.join("module_cache.json")
+        && config_file.exists()
+        && let Some(cache_completes) = CachedCompleteItems::read(config_file)
+        && !cache_completes.need_update()
+    {
+        return Ok(cache_completes.completions);
+    }
     let output = Command::new("cmake").arg("--help-modules").output()?.stdout;
     let temp = String::from_utf8_lossy(&output);
-    Ok(gen_builtin_modules(&temp))
-});
+    let modules = gen_builtin_modules(&temp);
+
+    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+        && std::fs::create_dir_all(cache_dir).is_ok()
+        && let config_file = cache_dir.join("module_cache.json")
+        && let cached = CachedCompleteItems::new(modules.clone())
+        && let Ok(data) = serde_json::to_string_pretty(&cached)
+    {
+        std::fs::write(config_file, data).ok();
+    }
+
+    Ok(modules)
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -374,7 +374,7 @@ pub static BUILTIN_MODULE: LazyLock<Result<Vec<CompletionItem>>> =
 fn get_builtin_modules() -> Result<Vec<CompletionItem>> {
     if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
-        && let config_file = cache_dir.join("module_cache.json")
+        && let config_file = cache_dir.join("builtin_module_cache.json")
         && config_file.exists()
         && let Some(cache_completes) = CachedCompleteItems::read(config_file)
         && !cache_completes.need_update()
@@ -387,7 +387,7 @@ fn get_builtin_modules() -> Result<Vec<CompletionItem>> {
 
     if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
-        && let config_file = cache_dir.join("module_cache.json")
+        && let config_file = cache_dir.join("builtin_module_cache.json")
         && let cached = CachedCompleteItems::new(modules.clone())
         && let Ok(data) = serde_json::to_string_pretty(&cached)
     {

--- a/src/complete/builtin.rs
+++ b/src/complete/builtin.rs
@@ -126,7 +126,7 @@ fn gen_builtin_command_signature_resource(
     return temp_iter.collect();
 }
 
-fn builtin_commands_cached_file<'a>(client_support_snippet: bool) -> &'a str {
+const fn builtin_commands_cached_file<'a>(client_support_snippet: bool) -> &'a str {
     if client_support_snippet {
         "builtin_commands.json"
     } else {
@@ -138,7 +138,7 @@ fn gen_builtin_commands() -> Vec<CompletionItem> {
     let client_support_snippet = to_use_snippet();
     let cached_file = builtin_commands_cached_file(client_support_snippet);
 
-    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+    if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
         && let config_file = cache_dir.join(cached_file)
         && config_file.exists()
@@ -199,7 +199,7 @@ fn gen_builtin_commands() -> Vec<CompletionItem> {
             ]
         })
         .collect();
-    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+    if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
         && let config_file = cache_dir.join(cached_file)
         && let cached = CachedCompleteItems::new(commands.clone())
@@ -211,7 +211,7 @@ fn gen_builtin_commands() -> Vec<CompletionItem> {
 }
 
 fn get_builtin_variables() -> Result<Vec<CompletionItem>> {
-    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+    if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
         && let config_file = cache_dir.join("builtin_variable_cache.json")
         && config_file.exists()
@@ -226,7 +226,7 @@ fn get_builtin_variables() -> Result<Vec<CompletionItem>> {
         .stdout;
     let temp = String::from_utf8_lossy(&output);
     let variables = gen_builtin_variables(&temp);
-    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+    if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
         && let config_file = cache_dir.join("builtin_variable_cache.json")
         && let cached = CachedCompleteItems::new(variables.clone())
@@ -378,7 +378,7 @@ pub static BUILTIN_MODULE_CACHED_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(
 });
 
 fn get_builtin_modules() -> Result<Vec<CompletionItem>> {
-    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+    if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
         && let config_file = cache_dir.join("module_cache.json")
         && config_file.exists()
@@ -391,7 +391,7 @@ fn get_builtin_modules() -> Result<Vec<CompletionItem>> {
     let temp = String::from_utf8_lossy(&output);
     let modules = gen_builtin_modules(&temp);
 
-    if let Some(cache_dir) = *&BUILTIN_MODULE_CACHED_DIR.as_ref()
+    if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
         && let config_file = cache_dir.join("module_cache.json")
         && let cached = CachedCompleteItems::new(modules.clone())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 
 use chrono::{DateTime, Local};
+use etcetera::BaseStrategy;
 use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::Uri;
@@ -15,25 +16,39 @@ pub use self::findpackage::*;
 use crate::fileapi;
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct CachedCompleteItems {
+pub struct CachedData<Data> {
     pub date: DateTime<Local>,
-    pub completions: Vec<CompletionItem>,
+    //pub data: Vec<CompletionItem>,
+    pub data: Data,
 }
 
-impl CachedCompleteItems {
+pub type CachedCompleteItems = CachedData<Vec<CompletionItem>>;
+
+pub type CachedMessages = CachedData<HashMap<String, String>>;
+
+pub static BUILTIN_MODULE_CACHED_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(|| {
+    let strategy = etcetera::choose_base_strategy().ok()?;
+    let cache_dir = strategy.cache_dir();
+    Some(cache_dir.join("neocmakelsp"))
+});
+
+impl<Data> CachedData<Data>
+where
+    Data: for<'a> Deserialize<'a>,
+{
     pub fn read<P: AsRef<Path>>(path: P) -> Option<Self> {
         let data = std::fs::read_to_string(path).ok()?;
         serde_json::from_str(&data).ok()
     }
 
-    pub fn new(completions: Vec<CompletionItem>) -> Self {
+    pub fn new(data: Data) -> Self {
         let dt = Local::now();
         // Get components
         let naive_utc = dt.naive_utc();
         let offset = *dt.offset();
         Self {
             date: DateTime::from_naive_utc_and_offset(naive_utc, offset),
-            completions,
+            data,
         }
     }
     pub fn need_update(&self) -> bool {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,7 @@ impl CachedCompleteItems {
         let dt = Local::now();
         // Get components
         let naive_utc = dt.naive_utc();
-        let offset = dt.offset().clone();
+        let offset = dt.offset();
         Self {
             date: DateTime::from_naive_utc_and_offset(naive_utc, offset),
             completions,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,14 +3,48 @@ pub mod query;
 pub mod treehelper;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 
+use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
+use tower_lsp::lsp_types::CompletionItem;
 use tower_lsp::lsp_types::Uri;
 
 pub use self::findpackage::*;
 use crate::fileapi;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CachedCompleteItems {
+    pub date: DateTime<Local>,
+    pub completions: Vec<CompletionItem>,
+}
+
+impl CachedCompleteItems {
+    pub fn read<P: AsRef<Path>>(path: P) -> Option<Self> {
+        let data = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&data).ok()
+    }
+
+    pub fn new(completions: Vec<CompletionItem>) -> Self {
+        let dt = Local::now();
+        // Get components
+        let naive_utc = dt.naive_utc();
+        let offset = dt.offset().clone();
+        Self {
+            date: DateTime::from_naive_utc_and_offset(naive_utc, offset),
+            completions,
+        }
+    }
+    pub fn need_update(&self) -> bool {
+        let utc = self.date.naive_utc();
+        let dt = Local::now();
+        // Get components
+        let naive_utc = dt.naive_utc();
+        let duration = naive_utc - utc;
+        duration.num_weeks() > 4
+    }
+}
 
 static PLACE_HODER_REGEX: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"\$\{(\w+)\}").unwrap());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,7 +30,7 @@ impl CachedCompleteItems {
         let dt = Local::now();
         // Get components
         let naive_utc = dt.naive_utc();
-        let offset = dt.offset();
+        let offset = *dt.offset();
         Self {
             date: DateTime::from_naive_utc_and_offset(naive_utc, offset),
             completions,

--- a/src/utils/treehelper.rs
+++ b/src/utils/treehelper.rs
@@ -167,7 +167,7 @@ pub static MESSAGE_STORAGE: LazyLock<HashMap<String, String>> = LazyLock::new(||
     );
     if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
         && std::fs::create_dir_all(cache_dir).is_ok()
-        && let config_file = cache_dir.join("module_cache.json")
+        && let config_file = cache_dir.join("messages_cache.json")
         && let cached = CachedMessages::new(storage.clone())
         && let Ok(data) = serde_json::to_string_pretty(&cached)
     {

--- a/src/utils/treehelper.rs
+++ b/src/utils/treehelper.rs
@@ -11,7 +11,7 @@ use tree_sitter::{Node, Point};
 use crate::{
     CMakeNodeKinds,
     utils::{
-        NeoStrExt,
+        BUILTIN_MODULE_CACHED_DIR, CachedMessages, NeoStrExt,
         query::{
             try_get_bracket_comment, try_get_function, try_get_line_comment, try_get_macro,
             try_get_normal_command, try_get_variable,
@@ -101,6 +101,15 @@ pub fn get_position_range(location: Position, root: Node) -> Option<Range> {
 }
 
 pub static MESSAGE_STORAGE: LazyLock<HashMap<String, String>> = LazyLock::new(|| {
+    if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
+        && std::fs::create_dir_all(cache_dir).is_ok()
+        && let config_file = cache_dir.join("messages_cache.json")
+        && config_file.exists()
+        && let Some(cache_completes) = CachedMessages::read(config_file)
+        && !cache_completes.need_update()
+    {
+        return cache_completes.data;
+    }
     let mut storage: HashMap<String, String> = HashMap::new();
     let re = regex::Regex::new(r"[z-zA-z]+\n-+").unwrap();
     if let Ok(output) = Command::new("cmake").arg("--help-commands").output() {
@@ -156,6 +165,14 @@ pub static MESSAGE_STORAGE: LazyLock<HashMap<String, String>> = LazyLock::new(||
         "pkg_check_modules".to_string(),
         "please FindPackage PkgConfig first".to_string(),
     );
+    if let Some(cache_dir) = BUILTIN_MODULE_CACHED_DIR.as_ref()
+        && std::fs::create_dir_all(cache_dir).is_ok()
+        && let config_file = cache_dir.join("module_cache.json")
+        && let cached = CachedMessages::new(storage.clone())
+        && let Ok(data) = serde_json::to_string_pretty(&cached)
+    {
+        std::fs::write(config_file, data).ok();
+    }
     storage
 });
 


### PR DESCRIPTION
Write json in $XDG_CONFIG_CACHE/neocmakelsp, to cache the data

with format like

```json
{
    "date": "2026...",
    "data:" {
    
    }
}
```

every 30 days, update the cache

issue: https://github.com/neocmakelsp/neocmakelsp/issues/296
